### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on: push
+
+jobs:
+
+  hlint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: 'Set up HLint'
+      uses: rwe/actions-hlint-setup@v1
+      with:
+        version: '3.3.4'
+
+    - name: 'Run HLint'
+      uses: rwe/actions-hlint-run@v2
+      with:
+        path: '["app/", "src/", "test/"]'
+        fail-on: warning
+
+  build:
+
+    needs: hlint
+
+    runs-on: ubuntu-latest
+
+    env:
+      CONFIG: "--enable-tests --enable-benchmarks"
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: haskell/actions/setup@v1.2
+      id: setup-haskell-cabal
+      with:
+        ghc-version: '8.10.7'
+        cabal-version: '3.4'
+
+    - name: Update Hackage snapshot
+      run: |
+        cabal update
+        cabal freeze $CONFIG
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-
+
+    - name: Build dependencies
+      run: cabal build --only-dependencies $CONFIG
+
+    - name: Build application
+      run: cabal build $CONFIG all
+
+    - name: Run tests
+      run: cabal test $CONFIG all
+
+    - name: Generate documentation
+      run: cabal haddock $CONFIG all
+
+    - name: Install binary
+      run: cabal install --enable-executable-static --install-method=copy --overwrite-policy=always --installdir=dist/
+
+    - name: Rename binary
+      run: mv dist/eselsohr-exe dist/eselsohr
+
+    - name: Store application binary as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: eselsohr
+        path: dist/eselsohr

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It’s still in an early stage of development and not ready for production.
 
 ## Build Eselsohr
 
+Pre-built binary releases are provided as CI artifacts.
+
 To build the project manually, you’ll need [GHC](https://en.wikipedia.org/wiki/Glasgow_Haskell_Compiler) and the [Cabal](https://www.haskell.org/cabal/) build tool.
 Download this repository and change your working directory into it.
 You can then install the executable with:

--- a/src/Lib/Impl/Repository.hs
+++ b/src/Lib/Impl/Repository.hs
@@ -190,7 +190,7 @@ updateSetter
   -> (a -> a)
   -> Resource
 updateSetter getter setter updater entId = gsetter getter setter setter'
-  where setter' _ oldRes = Map.adjust updater entId oldRes
+  where setter' _ = Map.adjust updater entId
 
 deleteSetter
   :: CollectionGetter a -> CollectionSetter a -> Resource -> Id a -> Resource


### PR DESCRIPTION
This PR adds a CI file for GitHub Actions. The current version builds the project and runs the test suite. The built Linux binary is available as artifact for each run. A separate job for hlint is also run (see #2).

Fixes #1 and #5.