### PR TITLE
Revert "Add environments like Prod, Test, or Dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ The following values can be set:
     Not set by default.
 * `KEY_FILE`: File path to the TLS key file.
     Not set by default.
-* `APP_ENVIRONMENT`: The environment the application is running in.
-    Can be `Prod`, `Test`, or `Dev`.
-    Defaults to `Prod`.
 
 Currently, all configuration parameters are optional so starting Eselsohr can be as simple as executing the Eselsohr binary.
 The `dist` directory in this repository provides deployment relevant files, like an example `rc` file for FreeBSD or a service file for systemd-based Linux distributions.

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -21,11 +21,7 @@ import           UnliftIO.Environment                                 ( getEnvir
                                                                       , unsetEnv
                                                                       )
 
-import qualified Lib.App.Env                                         as Env
-
-import           Lib.App.Env                                          ( DataPath
-                                                                      , Environment
-                                                                      )
+import           Lib.App.Env                                          ( DataPath )
 
 {- | Configuration options for Eselsohr.
  Can be configured via environment variables or config file.
@@ -57,9 +53,6 @@ data Config = Config
   , -- | File path to the TLS key file.
     -- Defaults to: 'key.pem'
     confKeyFile     :: !FilePath
-  , -- | The environment the application is running in.
-    -- Defaults to: @Prod@
-    confEnvironment :: !Environment
   }
 
 loadConfig :: (MonadCatch m, MonadIO m) => Maybe FilePath -> m Config
@@ -73,7 +66,6 @@ loadConfig mConfPath = do
   confDisableHsts <- getDisableHsts
   confCertFile    <- getCertFile
   confKeyFile     <- getKeyFile
-  confEnvironment <- getAppEnvironment
   clearEnv
   pure $ Config { .. }
  where
@@ -116,11 +108,6 @@ loadConfig mConfPath = do
 
   getKeyFile :: (MonadIO m) => m FilePath
   getKeyFile = maybe (pure "key.pem") sanitizePath =<< lookupEnv "KEY_FILE"
-
-  getAppEnvironment :: (MonadIO m) => m Environment
-  getAppEnvironment = lookupEnv "APP_ENVIRONMENT" >>= \case
-    Nothing -> pure Env.Prod
-    Just e  -> pure . fromMaybe Env.Prod . readMaybe $ toTitleCase e
 
 clearEnv :: (MonadIO m) => m ()
 clearEnv = traverse_ (unsetEnv . fst) =<< getEnvironment

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -39,12 +39,11 @@ import           Lib.Ui.Server                                        ( applicat
 mkAppEnv :: Config -> IO AppEnv
 mkAppEnv Config.Config {..} = do
   newWriteQueue <- newTQueueIO
-  let dataFolder  = confDataFolder
-      writeQueue  = newWriteQueue
-      logAction   = mainLogAction confLogSeverity
-      https       = if confHttps then Env.HttpsOn else Env.HttpsOff
-      hsts        = if confDisableHsts then Env.HstsOff else Env.HstsOn
-      environment = confEnvironment
+  let dataFolder = confDataFolder
+      writeQueue = newWriteQueue
+      logAction  = mainLogAction confLogSeverity
+      https      = if confHttps then Env.HttpsOn else Env.HttpsOff
+      hsts       = if confDisableHsts then Env.HstsOff else Env.HstsOn
   pure $ Env.Env { .. }
 
 runServer :: Config -> AppEnv -> IO ()

--- a/src/Lib/App/Env.hs
+++ b/src/Lib/App/Env.hs
@@ -5,7 +5,6 @@ module Lib.App.Env
   , WriteQueue
   , Https(..)
   , Hsts(..)
-  , Environment(..)
   , Env(..)
   , Has(..)
   , grab
@@ -29,16 +28,12 @@ data Https = HttpsOn | HttpsOff
 
 data Hsts = HstsOn | HstsOff
 
-data Environment = Prod | Test | Dev
-  deriving stock (Read)
-
 data Env (m :: Type -> Type) = Env
-  { dataFolder  :: !DataPath
-  , writeQueue  :: !(WriteQueue m)
-  , logAction   :: !(LogAction m Message)
-  , https       :: !Https
-  , hsts        :: !Hsts
-  , environment :: !Environment
+  { dataFolder          :: !DataPath
+  , writeQueue          :: !(WriteQueue m)
+  , logAction           :: !(LogAction m Message)
+  , https               :: !Https
+  , hsts                :: !Hsts
   }
 
 instance HasLog (Env m) Message m where
@@ -67,9 +62,6 @@ instance Has Https (Env m) where
 
 instance Has Hsts (Env m) where
   obtain = hsts
-
-instance Has Environment (Env m) where
-  obtain = environment
 
 grab :: forall field env m . (MonadReader env m, Has field env) => m field
 grab = asks $ obtain @field

--- a/src/Lib/Domain/Uri.hs
+++ b/src/Lib/Domain/Uri.hs
@@ -23,9 +23,6 @@ import           Validation                                           ( Validati
                                                                       , validationToEither
                                                                       )
 
-import qualified Lib.App.Env                                         as Env
-
-import           Lib.App.Env                                          ( Environment )
 import           Lib.Domain.Error                                     ( AppErrorType
                                                                       , invalid
                                                                       )
@@ -55,12 +52,10 @@ instance Show UriValidationError where
   show ForbiddenIPv4Range = "Only public IPv4 ranges are allowed."
   show ForbiddenIPv6Range = "Only public IPv6 ranges are allowed."
 
-mkUri :: Environment -> Text -> Either AppErrorType Uri
-mkUri env url = case U.mkURI url of
+mkUri :: Text -> Either AppErrorType Uri
+mkUri url = case U.mkURI url of
   Left  err -> Left . invalid . toText $ displayException err
-  Right uri -> case env of
-    Env.Prod   -> validationToEither . bimap (invalid . show) Uri $ validateUri uri
-    _testOrDev -> pure $ Uri uri
+  Right uri -> validationToEither . bimap (invalid . show) Uri $ validateUri uri
  where
   validateUri :: URI -> Validation (NonEmpty UriValidationError) URI
   validateUri = validateAll [validatePort, validateProtocol, validateHostname, validateIPv4, validateIPv6]

--- a/src/Lib/Infra/Persistence/Model/Article.hs
+++ b/src/Lib/Infra/Persistence/Model/Article.hs
@@ -14,7 +14,6 @@ import           Prelude                                       hiding ( id
 import qualified Lib.Domain.Article                                  as Domain
 import qualified Lib.Infra.Persistence.Model.Uri                     as Uri
 
-import           Lib.App.Env                                          ( Environment )
 import           Lib.Domain.Article                                   ( Article )
 import           Lib.Domain.Error                                     ( AppErrorType )
 import           Lib.Domain.Id                                        ( Id )
@@ -40,10 +39,10 @@ fromDomain domArt = do
       creation = Domain.creation domArt
   ArticlePm { .. }
 
-toDomain :: Environment -> ArticlePm -> Either AppErrorType Article
-toDomain env ArticlePm {..} = do
+toDomain :: ArticlePm -> Either AppErrorType Article
+toDomain ArticlePm {..} = do
   let domId = id
   domTitle <- Domain.titleFromText title
-  domUri   <- Uri.toDomain env uri
+  domUri   <- Uri.toDomain uri
   domState <- readOrMappingError state
   pure $ Domain.Article domId domTitle domUri domState creation

--- a/src/Lib/Infra/Persistence/Model/ArticleList.hs
+++ b/src/Lib/Infra/Persistence/Model/ArticleList.hs
@@ -9,7 +9,6 @@ import qualified Data.Map.Strict                                     as Map
 import qualified Lib.Domain.ArticleList                              as Domain
 import qualified Lib.Infra.Persistence.Model.Article                 as Article
 
-import           Lib.App.Env                                          ( Environment )
 import           Lib.Domain.Article                                   ( Article )
 import           Lib.Domain.ArticleList                               ( ArticleList )
 import           Lib.Domain.Error                                     ( AppErrorType )
@@ -24,5 +23,5 @@ type ArticleListPm = Map (Id Article) ArticlePm
 fromDomain :: ArticleList -> ArticleListPm
 fromDomain = Map.fromList . modelListFromDomain Article.fromDomain . Domain.toMap
 
-toDomain :: Environment -> ArticleListPm -> Either AppErrorType ArticleList
-toDomain env = Right . Domain.fromMap . Map.fromList <=< modelListToDomain (Article.toDomain env)
+toDomain :: ArticleListPm -> Either AppErrorType ArticleList
+toDomain = Right . Domain.fromMap . Map.fromList <=< modelListToDomain Article.toDomain

--- a/src/Lib/Infra/Persistence/Model/Uri.hs
+++ b/src/Lib/Infra/Persistence/Model/Uri.hs
@@ -6,7 +6,6 @@ module Lib.Infra.Persistence.Model.Uri
 
 import qualified Lib.Domain.Uri                                      as Domain
 
-import           Lib.App.Env                                          ( Environment )
 import           Lib.Domain.Error                                     ( AppErrorType )
 import           Lib.Domain.Uri                                       ( Uri )
 
@@ -15,5 +14,5 @@ type UriPm = Text
 fromDomain :: Uri -> UriPm
 fromDomain = toText
 
-toDomain :: Environment -> UriPm -> Either AppErrorType Uri
+toDomain :: UriPm -> Either AppErrorType Uri
 toDomain = Domain.mkUri

--- a/src/Lib/Infra/Repo/ArticleList.hs
+++ b/src/Lib/Infra/Repo/ArticleList.hs
@@ -10,10 +10,6 @@ import qualified Lib.Infra.Persistence.File                          as File
 import qualified Lib.Infra.Persistence.Model.ArticleList             as ArtListPm
 import qualified Lib.Infra.Persistence.Model.Collection              as ColPm
 
-import           Lib.App.Env                                          ( Environment
-                                                                      , Has
-                                                                      , grab
-                                                                      )
 import           Lib.App.Port                                         ( MonadRandom )
 import           Lib.Domain.Article                                   ( Article )
 import           Lib.Domain.ArticleList                               ( ArticleList )
@@ -30,21 +26,17 @@ import           Lib.Infra.Persistence.Queue                          ( WithQueu
                                                                       , commit
                                                                       )
 
-type WithAppEnv env m = (MonadReader env m, Has Environment env)
-
 nextId :: (MonadRandom m) => m (Id Article)
 nextId = Port.getRandomId
 
-saveAll
-  :: (WithAppEnv env m, WithError m, WithFile env m, WithQueue env m) => Id Collection -> Seq ArticleListAction -> m ()
+saveAll :: (WithError m, WithFile env m, WithQueue env m) => Id Collection -> Seq ArticleListAction -> m ()
 saveAll colId updates = do
   let action = File.save updater colId
   commit colId action
  where
-  updater :: (WithAppEnv env m, WithError m) => CollectionPm -> m CollectionPm
+  updater :: WithError m => CollectionPm -> m CollectionPm
   updater colPm = do
-    appEnv     <- grab @Environment
-    artList    <- throwOnError . ArtListPm.toDomain appEnv $ ColPm.articleList colPm
+    artList    <- throwOnError . ArtListPm.toDomain $ ColPm.articleList colPm
     newArtList <- throwOnError $ foldlM apply artList updates
     pure $ colPm { ColPm.articleList = ArtListPm.fromDomain newArtList }
 

--- a/src/Lib/Ui/Web/Controller/ArticleList.hs
+++ b/src/Lib/Ui/Web/Controller/ArticleList.hs
@@ -12,9 +12,6 @@ import qualified Lib.Ui.Web.Page.ShareArticle                        as ShareArt
 import qualified Lib.Ui.Web.Page.ShareArticleList                    as ShareArticleListPage
 import qualified Lib.Ui.Web.Route                                    as Route
 
-import           Lib.App.Env                                          ( Environment
-                                                                      , grab
-                                                                      )
 import           Lib.App.Port                                         ( MonadScraper )
 import           Lib.Domain.Article                                   ( Article )
 import           Lib.Domain.Capability                                ( Capability
@@ -37,8 +34,7 @@ import           Lib.Ui.Web.Dto.Form                                  ( ChangeAr
                                                                       , CreateSharedArticleRefForm(..)
                                                                       , DeleteItemForm(..)
                                                                       )
-import           Lib.Ui.Web.Page.Shared                               ( WithAppEnv
-                                                                      , WithQuery
+import           Lib.Ui.Web.Page.Shared                               ( WithQuery
                                                                       , lookupReferences
                                                                       )
 import           Lib.Ui.Web.Route                                     ( AppServer
@@ -64,17 +60,15 @@ articleList = Route.ArticleListSite { Route.articleListPage            = Article
                                     , Route.deleteSharedArticleRef     = deleteSharedArticleRef
                                     }
 
-createArticle
-  :: (ArticleListRepo m, MonadScraper m, WithAppEnv env m, WithQuery env m) => CreateArticleForm -> m Redirection
+createArticle :: (ArticleListRepo m, MonadScraper m, WithQuery env m) => CreateArticleForm -> m Redirection
 createArticle CreateArticleForm {..} = do
   (ref, objRef) <- lookupReferences acc
-  appEnv        <- grab @Environment
-  command       <- throwOnError . mkCommand objRef appEnv $ collectionId ref
+  command       <- throwOnError . mkCommand objRef $ collectionId ref
   throwOnErrorM $ Command.createArticle command
   redirectTo goto
  where
-  mkCommand objRef env colId = do
-    uri <- Uri.mkUri env articleUri
+  mkCommand objRef colId = do
+    uri <- Uri.mkUri articleUri
     Right Command.CreateArticle { .. }
 
 changeArticleTitle :: (ArticleListRepo m, WithQuery env m) => Id Article -> ChangeArticleTitleForm -> m Redirection

--- a/src/Lib/Ui/Web/Page/Article.hs
+++ b/src/Lib/Ui/Web/Page/Article.hs
@@ -26,8 +26,7 @@ import           Lib.Infra.Error                                      ( throwOnE
 import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
                                                                       , Reference(..)
                                                                       )
-import           Lib.Ui.Web.Page.Shared                               ( WithAppEnv
-                                                                      , WithQuery
+import           Lib.Ui.Web.Page.Shared                               ( WithQuery
                                                                       , deleteArticleForm
                                                                       , getArticle
                                                                       , lookupReferences
@@ -43,7 +42,7 @@ import           Lib.Ui.Web.Route                                     ( HtmlPage
 -- Handler
 ------------------------------------------------------------------------
 
-handler :: (WithAppEnv env m, WithQuery env m) => Id Article -> Maybe Accesstoken -> m HtmlPage
+handler :: WithQuery env m => Id Article -> Maybe Accesstoken -> m HtmlPage
 handler _artId Nothing    = Layout.renderM Static.notAuthorized
 handler artId  (Just acc) = do
   (ref, objRef) <- lookupReferences acc
@@ -61,7 +60,7 @@ data Query = Query
   , colId  :: !(Id Collection)
   }
 
-query :: (WithAppEnv env m, WithQuery env m) => Query -> m View
+query :: WithQuery env m => Query -> m View
 query Query {..} = do
   let canViewArticles       = isRight $ Authz.canViewArticles objRef
       canChangeArticleTitle = isRight $ Authz.canChangeArticleTitle objRef artId

--- a/src/Lib/Ui/Web/Page/ArticleList.hs
+++ b/src/Lib/Ui/Web/Page/ArticleList.hs
@@ -28,8 +28,7 @@ import           Lib.Infra.Error                                      ( throwOnE
 import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
                                                                       , Reference(..)
                                                                       )
-import           Lib.Ui.Web.Page.Shared                               ( WithAppEnv
-                                                                      , WithQuery
+import           Lib.Ui.Web.Page.Shared                               ( WithQuery
                                                                       , createArticleForm
                                                                       , deleteArticleForm
                                                                       , getArticleMap
@@ -46,7 +45,7 @@ import           Lib.Ui.Web.Route                                     ( HtmlPage
 -- Handler
 ------------------------------------------------------------------------
 
-handler :: (WithAppEnv env m, WithQuery env m) => Maybe Accesstoken -> m HtmlPage
+handler :: WithQuery env m => Maybe Accesstoken -> m HtmlPage
 handler Nothing    = Layout.renderM Static.notAuthorized
 handler (Just acc) = do
   (ref, objRef) <- lookupReferences acc
@@ -63,7 +62,7 @@ data Query = Query
   , colId  :: !(Id Collection)
   }
 
-query :: (WithAppEnv env m, WithQuery env m) => Query -> m View
+query :: WithQuery env m => Query -> m View
 query Query {..} = do
   let canCreateArticles     = isRight $ Authz.canCreateArticles objRef
       canChangeArticleTitle = isRight $ Authz.canChangeTitles objRef
@@ -74,7 +73,7 @@ query Query {..} = do
   articles         <- getArticles colId
   pure View { .. }
 
-getArticles :: (WithAppEnv env m, WithQuery env m) => Id Collection -> m (Seq ArticleVm)
+getArticles :: WithQuery env m => Id Collection -> m (Seq ArticleVm)
 getArticles = pure . Seq.fromList . Map.elems . toArticleVm <=< getArticleMap
   where toArticleVm = fmap ArticleVm.fromDomain
 

--- a/src/Lib/Ui/Web/Page/EditArticle.hs
+++ b/src/Lib/Ui/Web/Page/EditArticle.hs
@@ -23,8 +23,7 @@ import           Lib.Infra.Error                                      ( throwOnE
 import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
                                                                       , Reference(..)
                                                                       )
-import           Lib.Ui.Web.Page.Shared                               ( WithAppEnv
-                                                                      , WithQuery
+import           Lib.Ui.Web.Page.Shared                               ( WithQuery
                                                                       , changeArticleTitleForm
                                                                       , getArticle
                                                                       , lookupReferences
@@ -35,7 +34,7 @@ import           Lib.Ui.Web.Route                                     ( HtmlPage
 -- Handler
 ------------------------------------------------------------------------
 
-handler :: (WithAppEnv env m, WithQuery env m) => Id Article -> Maybe Accesstoken -> m HtmlPage
+handler :: WithQuery env m => Id Article -> Maybe Accesstoken -> m HtmlPage
 handler _artId Nothing    = Layout.renderM Static.notAuthorized
 handler artId  (Just acc) = do
   (ref, objRef) <- lookupReferences acc
@@ -53,7 +52,7 @@ data Query = Query
   , colId  :: !(Id Collection)
   }
 
-query :: (WithAppEnv env m, WithQuery env m) => Query -> m View
+query :: WithQuery env m => Query -> m View
 query Query {..} = do
   changeTitlePerm <- throwOnError $ Authz.canChangeArticleTitle objRef artId
   article         <- getArticle colId artId


### PR DESCRIPTION
This added a dependency from Domain to App which is wrong. If functions
in the domain layer depend on some configuration, it should be a concept
of the domain that also lives there and not be deployment related.

This reverts commit 16401ac09d4882991f65916e2fff657f367e18e8.