### PR TITLE
Allow disabled collection creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ The following values can be set:
 * `DEPLOYMENT_MODE`: The mode the application is running in.
     Can be `Prod`, `Test`, or `Dev`.
     Defaults to `Prod`.
+* `PUBLIC_COLLECTION_CREATION`: Wether the creation of collection should be public.
+    Defaults to `False`.
 
 Currently, all configuration parameters are optional so starting Eselsohr can be as simple as executing the Eselsohr binary.
+If you don’t allow the public creation of collections, you can generate accesstokens for collections by running `eselsohr-exe collection new`.
+
 The `dist` directory in this repository provides deployment relevant files, like an example `rc` file for FreeBSD or a service file for systemd-based Linux distributions.
 
 ### Docker-based

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,33 +1,89 @@
 module Main where
 
 import           Options.Applicative                                  ( (<**>)
+                                                                      , (<|>)
+                                                                      , CommandFields
+                                                                      , Mod
                                                                       , Parser
                                                                       , ParserInfo
+                                                                      , ParserPrefs(..)
+                                                                      , command
+                                                                      , commandGroup
+                                                                      , customExecParser
+                                                                      , defaultPrefs
                                                                       , execParser
                                                                       , fullDesc
                                                                       , header
                                                                       , help
                                                                       , helper
+                                                                      , hidden
                                                                       , info
                                                                       , long
                                                                       , optional
+                                                                      , prefs
                                                                       , progDesc
                                                                       , short
+                                                                      , showHelpOnError
                                                                       , strOption
+                                                                      , subparser
                                                                       )
 
+import qualified Cli
 import qualified Lib
 
-newtype ExeConfig = ExeConfig
-  { envPath :: Maybe FilePath
+import           Cli                                                  ( CliAction
+                                                                      , CollectionCommand
+                                                                      )
+
+data Options = Options
+  { envPath :: !(Maybe FilePath)
+  , action  :: !CliAction
   }
 
-config :: Parser ExeConfig
-config = ExeConfig <$> configFile
-  where configFile = optional (strOption (long "config-file" <> short 'c' <> help "Path to the env config file"))
+options :: ParserInfo Options
+options = info (parser <**> helper) (fullDesc <> progDesc "Run Eselsohr" <> header "Eselsohr")
+ where
+  command :: Parser CliAction
+  command = commandsP <|> runServerP
+
+  parser :: Parser Options
+  parser = Options <$> configP <*> command
 
 main :: IO ()
-main = Lib.main . envPath =<< execParser opts
+main = do
+  Options mConfPath action <- customExecParser preferences options
+  Lib.main mConfPath action
  where
-  opts :: ParserInfo ExeConfig
-  opts = info (config <**> helper) (fullDesc <> progDesc "Run Eselsohr" <> header "Eselsohr")
+  preferences :: ParserPrefs
+  preferences = defaultPrefs { prefDisambiguate = True, prefShowHelpOnError = True }
+
+------------------------------------------------------------------------
+-- Parser
+------------------------------------------------------------------------
+
+runServerP :: Parser CliAction
+runServerP = pure Cli.RunServer
+
+configP :: Parser (Maybe FilePath)
+configP = optional . strOption $ long "config-file" <> short 'c' <> help "Path to the env config file"
+
+commandsP :: Parser CliAction
+commandsP = longSubParser <|> shortSubParser
+ where
+  longSubParser :: Parser CliAction
+  longSubParser = subparser collectionCommand
+
+  shortSubParser :: Parser CliAction
+  shortSubParser = subparser (commandGroup "Short commands:" <> hidden <> collectionShortCommand)
+
+  collectionCommand :: Mod CommandFields CliAction
+  collectionCommand = command "collection" collectionParserInfo
+
+  collectionShortCommand :: Mod CommandFields CliAction
+  collectionShortCommand = command "c" collectionParserInfo
+
+  collectionParserInfo :: ParserInfo CliAction
+  collectionParserInfo = info (Cli.Collection <$> collectionP) (progDesc "Manage collections")
+
+  collectionP :: Parser CollectionCommand
+  collectionP = subparser $ command "new" (info (pure Cli.NewCollection) (progDesc "Create new collection"))

--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -13,6 +13,7 @@ extra-source-files: CHANGELOG.md
 
 library
     exposed-modules:
+        Cli
         Config
         Init
         Lib
@@ -53,6 +54,8 @@ library
         Lib.Infra.Repo.ArticleList
         Lib.Infra.Repo.CapabilityList
         Lib.Infra.Repo.Collection
+        Lib.Ui.Cli.Command
+        Lib.Ui.Cli.Handler
         Lib.Ui.Dto.Accesstoken
         Lib.Ui.Dto.Id
         Lib.Ui.Server

--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -53,14 +53,14 @@ library
         Lib.Infra.Repo.ArticleList
         Lib.Infra.Repo.CapabilityList
         Lib.Infra.Repo.Collection
+        Lib.Ui.Dto.Accesstoken
+        Lib.Ui.Dto.Id
         Lib.Ui.Server
         Lib.Ui.Web.Controller.ArticleList
         Lib.Ui.Web.Controller.Collection
         Lib.Ui.Web.Controller.Static
-        Lib.Ui.Web.Dto.Accesstoken
         Lib.Ui.Web.Dto.ExpirationDate
         Lib.Ui.Web.Dto.Form
-        Lib.Ui.Web.Dto.Id
         Lib.Ui.Web.Page.Article
         Lib.Ui.Web.Page.ArticleList
         Lib.Ui.Web.Page.CreateArticle

--- a/src/Cli.hs
+++ b/src/Cli.hs
@@ -1,0 +1,7 @@
+module Cli
+  ( module Lib.Ui.Cli.Handler
+  ) where
+
+import           Lib.Ui.Cli.Handler                                   ( CliAction(..)
+                                                                      , CollectionCommand(..)
+                                                                      )

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -43,12 +43,13 @@ import           Lib.Ui.Server                                        ( applicat
 mkAppEnv :: Config -> IO AppEnv
 mkAppEnv Config.Config {..} = do
   newWriteQueue <- newTQueueIO
-  let dataFolder     = confDataFolder
-      writeQueue     = newWriteQueue
-      logAction      = mainLogAction confLogSeverity
-      https          = if confHttps then Env.HttpsOn else Env.HttpsOff
-      hsts           = if confDisableHsts then Env.HstsOff else Env.HstsOn
-      deploymentMode = confDepMode
+  let dataFolder         = confDataFolder
+      writeQueue         = newWriteQueue
+      logAction          = mainLogAction confLogSeverity
+      https              = if confHttps then Env.HttpsOn else Env.HttpsOff
+      hsts               = if confDisableHsts then Env.HstsOff else Env.HstsOn
+      deploymentMode     = confDepMode
+      collectionCreation = if confPublicCollectionCreation then Env.Public else Env.Private
   pure $ Env.Env { .. }
 
 runServer :: Config -> AppEnv -> IO ()

--- a/src/Lib/App/Env.hs
+++ b/src/Lib/App/Env.hs
@@ -6,6 +6,7 @@ module Lib.App.Env
   , Https(..)
   , Hsts(..)
   , DeploymentMode(..)
+  , CollectionCreation(..)
   , Env(..)
   , Has(..)
   , grab
@@ -32,13 +33,16 @@ data Hsts = HstsOn | HstsOff
 data DeploymentMode = Prod | Test | Dev
   deriving stock (Read)
 
+data CollectionCreation = Public | Private
+
 data Env (m :: Type -> Type) = Env
-  { dataFolder     :: !DataPath
-  , writeQueue     :: !(WriteQueue m)
-  , logAction      :: !(LogAction m Message)
-  , https          :: !Https
-  , hsts           :: !Hsts
-  , deploymentMode :: !DeploymentMode
+  { dataFolder         :: !DataPath
+  , writeQueue         :: !(WriteQueue m)
+  , logAction          :: !(LogAction m Message)
+  , https              :: !Https
+  , hsts               :: !Hsts
+  , deploymentMode     :: !DeploymentMode
+  , collectionCreation :: !CollectionCreation
   }
 
 instance HasLog (Env m) Message m where
@@ -70,6 +74,9 @@ instance Has Hsts (Env m) where
 
 instance Has DeploymentMode (Env m) where
   obtain = deploymentMode
+
+instance Has CollectionCreation (Env m) where
+  obtain = collectionCreation
 
 grab :: forall field env m . (MonadReader env m, Has field env) => m field
 grab = asks $ obtain @field

--- a/src/Lib/Ui/Cli/Command.hs
+++ b/src/Lib/Ui/Cli/Command.hs
@@ -1,0 +1,15 @@
+module Lib.Ui.Cli.Command
+  ( createCollection
+  ) where
+
+import qualified Lib.App.Command                                     as Command
+import qualified Lib.Ui.Dto.Accesstoken                              as Accesstoken
+
+import           Lib.App.Port                                         ( MonadRandom )
+import           Lib.Domain.Repo.Collection                           ( CollectionRepo )
+
+createCollection :: (CollectionRepo m, MonadRandom m) => m Text
+createCollection = do
+  (colId, capId) <- Command.createCollection
+  let acc = Accesstoken.mkAccesstoken $ Accesstoken.Reference colId capId
+  pure $ Accesstoken.encodeToBase32 acc

--- a/src/Lib/Ui/Cli/Handler.hs
+++ b/src/Lib/Ui/Cli/Handler.hs
@@ -1,0 +1,29 @@
+module Lib.Ui.Cli.Handler
+  ( CliAction(..)
+  , CollectionCommand(..)
+  , commandHandler
+  , runCli
+  ) where
+
+import qualified Lib.Ui.Cli.Command                                  as Command
+
+import           Lib.App.Port                                         ( MonadRandom )
+import           Lib.Domain.Repo.Collection                           ( CollectionRepo )
+import           Lib.Infra.Log                                        ( runAppLogIO_ )
+import           Lib.Infra.Monad                                      ( AppEnv )
+
+data CliAction
+  = RunServer
+  | Collection CollectionCommand
+
+data CollectionCommand = NewCollection
+
+commandHandler :: (CollectionRepo m, MonadRandom m, MonadIO m) => CliAction -> m ()
+commandHandler RunServer                = pure ()
+commandHandler (Collection colCommands) = case colCommands of
+  NewCollection -> do
+    acc <- Command.createCollection
+    putStrLn $ "Accesstoken: " <> toString acc
+
+runCli :: AppEnv -> CliAction -> IO ()
+runCli env = runAppLogIO_ env . commandHandler

--- a/src/Lib/Ui/Dto/Accesstoken.hs
+++ b/src/Lib/Ui/Dto/Accesstoken.hs
@@ -1,4 +1,4 @@
-module Lib.Ui.Web.Dto.Accesstoken
+module Lib.Ui.Dto.Accesstoken
   ( Accesstoken
   , Reference(..)
   , mkAccesstoken

--- a/src/Lib/Ui/Dto/Accesstoken.hs
+++ b/src/Lib/Ui/Dto/Accesstoken.hs
@@ -3,6 +3,8 @@ module Lib.Ui.Dto.Accesstoken
   , Reference(..)
   , mkAccesstoken
   , toReference
+  , encodeToBase32
+  , decodeFromBase32
   ) where
 
 import qualified Codec.Serialise                                     as Ser
@@ -50,13 +52,19 @@ instance Show Accesstoken where
   show = toString . toUrlPiece
 
 instance ToHttpApiData Accesstoken where
-  toUrlPiece = decodeUtf8 . encodeBase32Unpadded' . unAccesstoken
+  toUrlPiece = encodeToBase32
 
 instance FromHttpApiData Accesstoken where
-  parseUrlPiece = either (const $ Left "invalid UrlToken") (Right . Accesstoken) . decodeBase32 . encodeUtf8
+  parseUrlPiece = decodeFromBase32
 
 mkAccesstoken :: Reference -> Accesstoken
 mkAccesstoken = Accesstoken . Ser.serialise . fromDomain
 
 toReference :: Accesstoken -> Reference
 toReference = toDomain . Ser.deserialise . unAccesstoken
+
+encodeToBase32 :: Accesstoken -> Text
+encodeToBase32 = decodeUtf8 . encodeBase32Unpadded' . unAccesstoken
+
+decodeFromBase32 :: Text -> Either Text Accesstoken
+decodeFromBase32 = either (const $ Left "invalid UrlToken") (Right . Accesstoken) . decodeBase32 . encodeUtf8

--- a/src/Lib/Ui/Dto/Id.hs
+++ b/src/Lib/Ui/Dto/Id.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Lib.Ui.Web.Dto.Id where
+module Lib.Ui.Dto.Id where
 
 import           Data.UUID                                            ( UUID )
 import           Web.HttpApiData                                      ( FromHttpApiData

--- a/src/Lib/Ui/Web/Controller/ArticleList.hs
+++ b/src/Lib/Ui/Web/Controller/ArticleList.hs
@@ -30,7 +30,7 @@ import           Lib.Infra.Error                                      ( redirect
                                                                       , throwOnError
                                                                       , throwOnErrorM
                                                                       )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( collectionId )
+import           Lib.Ui.Dto.Accesstoken                               ( collectionId )
 import           Lib.Ui.Web.Dto.ExpirationDate                        ( ExpirationDate(..) )
 import           Lib.Ui.Web.Dto.Form                                  ( ChangeArticleStateForm(..)
                                                                       , ChangeArticleTitleForm(..)

--- a/src/Lib/Ui/Web/Controller/Collection.hs
+++ b/src/Lib/Ui/Web/Controller/Collection.hs
@@ -20,7 +20,7 @@ import           Lib.Infra.Error                                      ( WithErro
                                                                       , redirectTo
                                                                       , throwOnErrorM
                                                                       )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Reference(..)
+import           Lib.Ui.Dto.Accesstoken                               ( Reference(..)
                                                                       , mkAccesstoken
                                                                       )
 import           Lib.Ui.Web.Dto.ExpirationDate                        ( ExpirationDate(..) )

--- a/src/Lib/Ui/Web/Controller/Static.hs
+++ b/src/Lib/Ui/Web/Controller/Static.hs
@@ -6,22 +6,33 @@ module Lib.Ui.Web.Controller.Static
 
 import           Clay                                                 ( Css )
 
+import qualified Lib.App.Env                                         as Env
 import qualified Lib.Ui.Web.Page.Layout                              as Layout
 import qualified Lib.Ui.Web.Page.Static                              as Static
 import qualified Lib.Ui.Web.Page.Style                               as Style
 import qualified Lib.Ui.Web.Route                                    as Route
 
+import           Lib.App.Env                                          ( CollectionCreation
+                                                                      , Has
+                                                                      , grab
+                                                                      )
 import           Lib.Ui.Web.Route                                     ( AppServer
                                                                       , HtmlPage
                                                                       , StaticSite
                                                                       )
 
+type WithEnv env m = (MonadReader env m, Has CollectionCreation env)
+
 static :: StaticSite AppServer
 static =
   Route.StaticSite { Route.startpage = startpage, Route.invalidToken = invalidToken, Route.stylesheet = stylesheet }
 
-startpage :: (Monad m) => m HtmlPage
-startpage = Layout.renderM Static.startPage
+startpage :: WithEnv env m => m HtmlPage
+startpage = do
+  collectionCreation <- grab @CollectionCreation
+  case collectionCreation of
+    Env.Public  -> Layout.renderM $ Static.startPage True
+    Env.Private -> Layout.renderM $ Static.startPage False
 
 invalidToken :: (Monad m) => m HtmlPage
 invalidToken = Layout.renderM Static.invalidToken

--- a/src/Lib/Ui/Web/Dto/Form.hs
+++ b/src/Lib/Ui/Web/Dto/Form.hs
@@ -13,7 +13,7 @@ import           Web.FormUrlEncoded                                   ( FromForm
                                                                       , ToForm
                                                                       )
 
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken )
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken )
 import           Lib.Ui.Web.Dto.ExpirationDate                        ( ExpirationDate )
 
 data CreateArticleForm = CreateArticleForm

--- a/src/Lib/Ui/Web/Page/Article.hs
+++ b/src/Lib/Ui/Web/Page/Article.hs
@@ -23,7 +23,7 @@ import           Lib.Domain.Capability                                ( ObjectRe
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/ArticleList.hs
+++ b/src/Lib/Ui/Web/Page/ArticleList.hs
@@ -25,7 +25,7 @@ import           Lib.Domain.Capability                                ( ObjectRe
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/CollectionOverview.hs
+++ b/src/Lib/Ui/Web/Page/CollectionOverview.hs
@@ -30,7 +30,7 @@ import           Lib.Domain.Capability                                ( Capabili
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/CreateArticle.hs
+++ b/src/Lib/Ui/Web/Page/CreateArticle.hs
@@ -14,7 +14,7 @@ import qualified Lib.Ui.Web.Route                                    as Route
 
 import           Lib.Domain.Authorization                             ( CreateArticlesPerm )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken )
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery
                                                                       , createArticleForm
                                                                       , lookupReferences
@@ -46,4 +46,3 @@ view View {..} = do
   h1_ "Add a new article"
   createArticleForm acc goto
   where goto = fieldLink Route.createArticlePage $ Just acc
-

--- a/src/Lib/Ui/Web/Page/EditArticle.hs
+++ b/src/Lib/Ui/Web/Page/EditArticle.hs
@@ -20,7 +20,7 @@ import           Lib.Domain.Capability                                ( ObjectRe
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/ShareArticle.hs
+++ b/src/Lib/Ui/Web/Page/ShareArticle.hs
@@ -24,7 +24,7 @@ import           Lib.Domain.Capability                                ( ObjectRe
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/ShareArticleList.hs
+++ b/src/Lib/Ui/Web/Page/ShareArticleList.hs
@@ -23,7 +23,7 @@ import           Lib.Domain.Capability                                ( ObjectRe
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/ShareCollectionOverview.hs
+++ b/src/Lib/Ui/Web/Page/ShareCollectionOverview.hs
@@ -25,7 +25,7 @@ import           Lib.Domain.Capability                                ( ObjectRe
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Error                                      ( throwOnError )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       )
 import           Lib.Ui.Web.Page.Shared                               ( WithQuery

--- a/src/Lib/Ui/Web/Page/Shared.hs
+++ b/src/Lib/Ui/Web/Page/Shared.hs
@@ -78,11 +78,11 @@ import           Lib.Infra.Persistence.File                           ( WithFile
 import           Lib.Infra.Persistence.Model.ArticleList              ( ArticleListPm )
 import           Lib.Infra.Persistence.Model.Capability               ( CapabilityPm )
 import           Lib.Infra.Persistence.Model.CapabilityList           ( CapabilityListPm )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       , toReference
                                                                       )
-import           Lib.Ui.Web.Dto.Id                                    ( )
+import           Lib.Ui.Dto.Id                                        ( )
 import           Lib.Ui.Web.Page.ViewModel.Article                    ( ArticleVm )
 import           Lib.Ui.Web.Page.ViewModel.Permission                 ( ArticlePermsVm(..)
                                                                       , ArticlesPermsVm(..)

--- a/src/Lib/Ui/Web/Page/Static.hs
+++ b/src/Lib/Ui/Web/Page/Static.hs
@@ -8,14 +8,14 @@ import           Lucid
 
 import           Lib.Ui.Web.Page.Shared                               ( createCollectionForm )
 
-startPage :: Html ()
-startPage = do
+startPage :: Bool -> Html ()
+startPage publicCollectionCreation = do
   h1_ "Welcome to Eselsohr"
   p_
     "Eselsohr is a service focused on simplicity.\
     \ Save web articles and consume them later.\
     \ Start your collection by clicking on the button."
-  createCollectionForm
+  when publicCollectionCreation createCollectionForm
 
 invalidToken :: Html ()
 invalidToken = do

--- a/src/Lib/Ui/Web/Page/ViewModel/UnlockLink.hs
+++ b/src/Lib/Ui/Web/Page/ViewModel/UnlockLink.hs
@@ -8,7 +8,7 @@ import qualified Lib.Ui.Web.Page.ViewModel.Capability                as Capabili
 import           Lib.Domain.Capability                                ( Capability )
 import           Lib.Domain.Collection                                ( Collection )
 import           Lib.Domain.Id                                        ( Id )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken
                                                                       , Reference(..)
                                                                       , mkAccesstoken
                                                                       )

--- a/src/Lib/Ui/Web/Route.hs
+++ b/src/Lib/Ui/Web/Route.hs
@@ -36,7 +36,7 @@ import           Lib.Domain.Article                                   ( Article 
 import           Lib.Domain.Capability                                ( Capability )
 import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Monad                                      ( App )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken )
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken )
 import           Lib.Ui.Web.Dto.Form                                  ( ChangeArticleStateForm
                                                                       , ChangeArticleTitleForm
                                                                       , CreateArticleForm

--- a/test/Test/Ui/Web/Controller/ArticleList.hs
+++ b/test/Test/Ui/Web/Controller/ArticleList.hs
@@ -17,7 +17,7 @@ import           Web.FormUrlEncoded                                   ( urlEncod
 
 import           Lib.Ui.Web.Route                                    as Route
 
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken )
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken )
 import           Lib.Ui.Web.Dto.Form                                  ( CreateArticleForm(..) )
 import           Test.Ui.Web.Controller.Shared                        ( accFromPath
                                                                       , accFromResponse

--- a/test/Test/Ui/Web/Controller/Shared.hs
+++ b/test/Test/Ui/Web/Controller/Shared.hs
@@ -60,7 +60,7 @@ import           Lib                                                  ( mkAppEnv
                                                                       )
 import           Lib.Infra.Log                                        ( runAppLogIO_ )
 import           Lib.Infra.Monad                                      ( AppEnv )
-import           Lib.Ui.Dto.Accesstoken                           ( Accesstoken )
+import           Lib.Ui.Dto.Accesstoken                               ( Accesstoken )
 import           Lib.Ui.Web.Dto.Form                                  ( CreateUnlockLinkForm(..) )
 import           Lib.Ui.Web.Route                                     ( linkAsText )
 
@@ -92,7 +92,10 @@ withTestEnv = bracket setup clean
   setConfig conf = do
     tmpDir   <- getTemporaryDirectory
     filePath <- addTrailingPathSeparator <$> createTempDirectory tmpDir "eselsohr_test"
-    pure $ conf { Config.confDataFolder = filePath, Config.confDepMode = Env.Test }
+    pure $ conf { Config.confDataFolder               = filePath
+                , Config.confDepMode                  = Env.Test
+                , Config.confPublicCollectionCreation = True
+                }
 
   testServer :: AppEnv -> IO ()
   testServer = runSettings (warpSettings "127.0.0.1" 6980) . Server.application 6980

--- a/test/Test/Ui/Web/Controller/Shared.hs
+++ b/test/Test/Ui/Web/Controller/Shared.hs
@@ -60,7 +60,7 @@ import           Lib                                                  ( mkAppEnv
                                                                       )
 import           Lib.Infra.Log                                        ( runAppLogIO_ )
 import           Lib.Infra.Monad                                      ( AppEnv )
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Accesstoken )
+import           Lib.Ui.Dto.Accesstoken                           ( Accesstoken )
 import           Lib.Ui.Web.Dto.Form                                  ( CreateUnlockLinkForm(..) )
 import           Lib.Ui.Web.Route                                     ( linkAsText )
 

--- a/test/Test/Ui/Web/Dto/Accesstoken.hs
+++ b/test/Test/Ui/Web/Dto/Accesstoken.hs
@@ -14,9 +14,9 @@ import           Web.HttpApiData                                      ( parseUrl
                                                                       )
 
 import qualified Lib.Infra.Adapter.Random                            as Adapter
-import qualified Lib.Ui.Web.Dto.Accesstoken                          as Accesstoken
+import qualified Lib.Ui.Dto.Accesstoken                          as Accesstoken
 
-import           Lib.Ui.Web.Dto.Accesstoken                           ( Reference )
+import           Lib.Ui.Dto.Accesstoken                           ( Reference )
 
 accesstokenProps :: Group
 accesstokenProps = Group


### PR DESCRIPTION
This PR adds the config option `PUBLIC_COLLECTION_CREATION` that allows people to disable the public creation of collections.
A fallback by creating accesstokens locally is provided.

Fixes #43 