### PR TITLE
Add page for unlocking a collection

### DIFF
--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -67,6 +67,7 @@ library
         Lib.Ui.Web.Page.Article
         Lib.Ui.Web.Page.ArticleList
         Lib.Ui.Web.Page.CreateArticle
+        Lib.Ui.Web.Page.CollectionOverview
         Lib.Ui.Web.Page.EditArticle
         Lib.Ui.Web.Page.Layout
         Lib.Ui.Web.Page.ShareArticle
@@ -75,7 +76,7 @@ library
         Lib.Ui.Web.Page.Shared
         Lib.Ui.Web.Page.Static
         Lib.Ui.Web.Page.Style
-        Lib.Ui.Web.Page.CollectionOverview
+        Lib.Ui.Web.Page.UnlockCollection
         Lib.Ui.Web.Page.ViewModel.Article
         Lib.Ui.Web.Page.ViewModel.Capability
         Lib.Ui.Web.Page.ViewModel.Permission

--- a/src/Lib/Ui/Web/Controller/Collection.hs
+++ b/src/Lib/Ui/Web/Controller/Collection.hs
@@ -8,6 +8,7 @@ import qualified Lib.App.Command                                     as Command
 import qualified Lib.App.Env                                         as Env
 import qualified Lib.Ui.Web.Page.CollectionOverview                  as CollectionOverviewPage
 import qualified Lib.Ui.Web.Page.ShareCollectionOverview             as ShareCollectionOverviewPage
+import qualified Lib.Ui.Web.Page.UnlockCollection                    as UnlockCollectionPage
 import qualified Lib.Ui.Web.Route                                    as Route
 
 import           Lib.App.Env                                          ( CollectionCreation
@@ -44,6 +45,7 @@ import           Lib.Ui.Web.Route                                     ( AppServe
 collection :: CollectionSite AppServer
 collection = Route.CollectionSite { Route.createCollection        = createCollection
                                   , Route.overviewPage            = CollectionOverviewPage.handler
+                                  , Route.unlockCollection        = UnlockCollectionPage.handler
                                   , Route.createUnlockLink        = createUnlockLink
                                   , Route.deleteUnlockLink        = deleteUnlockLink
                                   , Route.shareOverviewPage       = ShareCollectionOverviewPage.handler

--- a/src/Lib/Ui/Web/Page/Shared.hs
+++ b/src/Lib/Ui/Web/Page/Shared.hs
@@ -19,6 +19,7 @@ module Lib.Ui.Web.Page.Shared
 
     -- ** HTML form related
   , createCollectionForm
+  , unlockCollectionForm
   , createUnlockLinkForm
   , deleteUnlockLinkForm
   , createSharedOverviewRefForm
@@ -185,6 +186,9 @@ createCollectionForm :: Html ()
 createCollectionForm = form_ [linkAbsAction_ $ fieldLink Route.createCollection, method_ "POST"] $ do
   input_ [type_ "submit", value_ "Create new collection"]
 
+unlockCollectionForm :: Html ()
+unlockCollectionForm = genGet (fieldLink Route.overviewPage Nothing) [] "Unlock collection"
+
 createUnlockLinkForm :: UTCTime -> UTCTime -> Accesstoken -> Link -> Html ()
 createUnlockLinkForm currTime expTime =
   postMethodButton (fieldLink Route.createUnlockLink) [createLink currTime expTime] "Create access link"
@@ -270,6 +274,12 @@ deleteSharedArticleRefForm articleId sharedArticleIdRef =
   deleteMethodLink (fieldLink Route.deleteSharedArticleRef articleId sharedArticleIdRef) [] "Delete shared article link"
 
 -- Helper
+
+genGet :: Link -> [Html ()] -> Text -> Html ()
+genGet route inputFields buttonName = form_ [linkAbsAction_ route, method_ "GET"] $ do
+  input_ [name_ "acc"]
+  sequenceA_ inputFields
+  input_ [type_ "submit", value_ buttonName]
 
 genPost :: Bool -> Text -> Link -> [Html ()] -> Text -> Accesstoken -> Link -> Html ()
 genPost asLink commandMethod route inputFields buttonName acc gotoUrl =

--- a/src/Lib/Ui/Web/Page/Static.hs
+++ b/src/Lib/Ui/Web/Page/Static.hs
@@ -1,21 +1,39 @@
 module Lib.Ui.Web.Page.Static
   ( startPage
+  , unlockCollection
   , invalidToken
   , notAuthorized
   ) where
 
 import           Lucid
+import           Lucid.Servant                                        ( linkAbsHref_ )
+import           Servant                                              ( fieldLink )
 
-import           Lib.Ui.Web.Page.Shared                               ( createCollectionForm )
+import qualified Lib.Ui.Web.Route                                    as Route
+
+import           Lib.Ui.Web.Page.Shared                               ( createCollectionForm
+                                                                      , unlockCollectionForm
+                                                                      )
 
 startPage :: Bool -> Html ()
 startPage publicCollectionCreation = do
   h1_ "Welcome to Eselsohr"
-  p_
-    "Eselsohr is a service focused on simplicity.\
-    \ Save web articles and consume them later.\
-    \ Start your collection by clicking on the button."
-  when publicCollectionCreation createCollectionForm
+  p_ "Eselsohr is a service focused on simplicity.\
+    \ Save web articles and consume them later."
+
+  p_ $ do
+    "Open an existing collection: "
+    a_ [linkAbsHref_ $ fieldLink Route.unlockCollection] "Unlock collection"
+
+  when publicCollectionCreation $ do
+    p_ "Create a new collection:"
+    createCollectionForm
+
+unlockCollection :: Html ()
+unlockCollection = do
+  h1_ "Unlock collection"
+  p_ "Please provide the accesstoken for your collection."
+  unlockCollectionForm
 
 invalidToken :: Html ()
 invalidToken = do

--- a/src/Lib/Ui/Web/Page/UnlockCollection.hs
+++ b/src/Lib/Ui/Web/Page/UnlockCollection.hs
@@ -1,0 +1,11 @@
+module Lib.Ui.Web.Page.UnlockCollection
+  ( handler
+  ) where
+
+import qualified Lib.Ui.Web.Page.Layout                              as Layout
+import qualified Lib.Ui.Web.Page.Static                              as Static
+
+import           Lib.Ui.Web.Route                                     ( HtmlPage )
+
+handler :: (Monad m) => m HtmlPage
+handler = Layout.renderM Static.unlockCollection

--- a/src/Lib/Ui/Web/Route.hs
+++ b/src/Lib/Ui/Web/Route.hs
@@ -67,6 +67,11 @@ data CollectionSite route = CollectionSite
         :- "collections"
         :> QueryParam "acc" Accesstoken
         :> Get '[HTML] HtmlPage
+  , unlockCollection ::
+      route
+        :- "collections"
+        :> "unlock"
+        :> Get '[HTML] HtmlPage
   , createUnlockLink ::
       route
         :- "collections"


### PR DESCRIPTION
This can be used by people who only got an accesstoken.
It can later be used for adding additional protection mechanisms.