### PR TITLE
Add migration support

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,10 +71,20 @@ commandsP :: Parser CliAction
 commandsP = longSubParser <|> shortSubParser
  where
   longSubParser :: Parser CliAction
-  longSubParser = subparser collectionCommand
+  longSubParser = subparser (collectionCommand <> migrateCommand)
 
   shortSubParser :: Parser CliAction
-  shortSubParser = subparser (commandGroup "Short commands:" <> hidden <> collectionShortCommand)
+  shortSubParser =
+    subparser (commandGroup "Short commands:" <> hidden <> collectionShortCommand <> migrateShortCommand)
+
+  migrateCommand :: Mod CommandFields CliAction
+  migrateCommand = command "migrate" migrateParserInfo
+
+  migrateShortCommand :: Mod CommandFields CliAction
+  migrateShortCommand = command "m" migrateParserInfo
+
+  migrateParserInfo :: ParserInfo CliAction
+  migrateParserInfo = info (pure Cli.Migrate) (progDesc "Migrate collections")
 
   collectionCommand :: Mod CommandFields CliAction
   collectionCommand = command "collection" collectionParserInfo

--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -104,6 +104,7 @@ library
         -fwrite-ide-info -hiedir=.hie -Wunused-packages -j -freverse-errors
 
     build-depends:
+        aeson >=2.0.2 && <2.1,
         base >=4.14.1 && <4.17,
         base32 >=0.2.0 && <0.3,
         clay >=0.13.3 && <0.14,
@@ -138,7 +139,8 @@ library
         wai-enforce-https >=0.0.2 && <1.1,
         wai-extra >=3.1.4.0 && <3.2,
         warp >=3.3.13 && <3.4,
-        warp-tls >=3.3.0 && <3.4
+        warp-tls >=3.3.0 && <3.4,
+        zlib >=0.6.2 && <0.7
 
     mixins:
         base hiding (Prelude),

--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -82,6 +82,7 @@ library
         Lib.Ui.Web.Page.ViewModel.Permission
         Lib.Ui.Web.Page.ViewModel.UnlockLink
         Lib.Ui.Web.Route
+        Migration
         Net.IPv6.Helper
         Network.Wai.Middleware.AddHsts
         Network.Wai.Middleware.NoOp

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -29,6 +29,7 @@ import qualified Config
 import qualified Init
 import qualified Lib.App.Env                                         as Env
 import qualified Lib.Ui.Cli.Handler                                  as Cli
+import qualified Migration
 
 import           Config                                               ( Config
                                                                       , loadConfig
@@ -117,4 +118,5 @@ main mConfPath command = do
   env  <- mkAppEnv conf
   case command of
     Cli.RunServer    -> runServer conf env
+    Cli.Migrate      -> Migration.migrate $ Config.confDataFolder conf
     _otherCliCommand -> Cli.runCli env command

--- a/src/Lib/Infra/Error.hs
+++ b/src/Lib/Infra/Error.hs
@@ -16,6 +16,8 @@ module Lib.Infra.Error
   ) where
 
 import qualified Control.Monad.Except                                as E
+import qualified Servant.Server                                      as Servant
+                                                                      ( ServerError )
 
 import           Control.Monad.Except                                 ( MonadError )
 import           GHC.Stack                                            ( SrcLoc(..) )
@@ -30,8 +32,6 @@ import           Servant                                              ( err303
                                                                       , errBody
                                                                       , errHeaders
                                                                       )
-import qualified Servant.Server                                      as Servant
-                                                                      ( ServerError )
 
 import           Lib.Domain.Error                                     ( AppErrorType(..)
                                                                       , IError(..)
@@ -137,4 +137,3 @@ throwOnErrorM action = withFrozenCallStack . either throwError pure =<< action
 -}
 redirectTo :: WithError m => Text -> m a
 redirectTo = throwError . redirect303
-

--- a/src/Lib/Infra/Persistence/File.hs
+++ b/src/Lib/Infra/Persistence/File.hs
@@ -4,6 +4,8 @@ module Lib.Infra.Persistence.File
   , load
   , init
   , save
+  , decodeFile
+  , encodeFile
   ) where
 
 
@@ -47,13 +49,13 @@ save colId col = do
   filePath <- idToPath colId
   encodeFile filePath col
 
-decodeFile :: (FromJSON a, WithFile env m) => FilePath -> m a
+decodeFile :: (FromJSON a, MonadIO m) => FilePath -> m a
 decodeFile fp = do
   mContent <- decode . GZip.decompress <$> readFileLBS fp
   maybe (error "Could not decode file") pure mContent
 {-# INLINE decodeFile #-}
 
-encodeFile :: (ToJSON a, WithFile env m) => FilePath -> a -> m ()
+encodeFile :: (ToJSON a, MonadIO m) => FilePath -> a -> m ()
 encodeFile fp = writeBinaryFileDurableAtomic fp . toStrict . GZip.compress . encode
 {-# INLINE encodeFile #-}
 

--- a/src/Lib/Infra/Persistence/Model/Article.hs
+++ b/src/Lib/Infra/Persistence/Model/Article.hs
@@ -1,11 +1,14 @@
 module Lib.Infra.Persistence.Model.Article
-  ( ArticlePm(..)
+  ( ArticlePm
   , fromDomain
   , toDomain
+  , migrate
   ) where
 
 import           Data.Aeson.Types                                     ( FromJSON
-                                                                      , ToJSON
+                                                                      , ToJSON(..)
+                                                                      , defaultOptions
+                                                                      , genericToEncoding
                                                                       )
 import           Data.Time.Clock                                      ( UTCTime )
 import           Prelude                                       hiding ( id
@@ -21,29 +24,56 @@ import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Persistence.Model.Id                       ( )
 import           Lib.Infra.Persistence.Model.Shared                   ( readOrMappingError )
 
-data ArticlePm = ArticlePm
-  { id       :: !(Id Article)
-  , title    :: !Text
-  , uri      :: !Text
-  , state    :: !Text
-  , creation :: !UTCTime
+data ArticlePm
+    = ArticlePmInit !ArticlePmV1Data
+    | ArticlePmV1 !ArticlePmV1Data
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+instance ToJSON ArticlePm where
+  toEncoding = genericToEncoding defaultOptions
+
+data ArticlePmV1Data = ArticlePmV1Data
+  { v1Id       :: !(Id Article)
+  , v1Title    :: !Text
+  , v1Uri      :: !Text
+  , v1State    :: !Text
+  , v1Creation :: !UTCTime
   }
   deriving stock Generic
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass FromJSON
+
+instance ToJSON ArticlePmV1Data where
+  toEncoding = genericToEncoding defaultOptions
+
+------------------------------------------------------------------------
+-- Mapper
+------------------------------------------------------------------------
 
 fromDomain :: Article -> ArticlePm
 fromDomain domArt = do
-  let id       = Domain.id domArt
-      title    = toText $ Domain.title domArt
-      uri      = Uri.fromDomain $ Domain.uri domArt
-      state    = show $ Domain.state domArt
-      creation = Domain.creation domArt
-  ArticlePm { .. }
+  let v1Id       = Domain.id domArt
+      v1Title    = toText $ Domain.title domArt
+      v1Uri      = Uri.fromDomain $ Domain.uri domArt
+      v1State    = show $ Domain.state domArt
+      v1Creation = Domain.creation domArt
+  ArticlePmV1 $ ArticlePmV1Data { .. }
 
 toDomain :: ArticlePm -> Either AppErrorType Article
-toDomain ArticlePm {..} = do
-  let domId = id
-  domTitle <- Domain.titleFromText title
-  domUri   <- Uri.toDomain uri
-  domState <- readOrMappingError state
-  pure $ Domain.Article domId domTitle domUri domState creation
+toDomain art = case art of
+  ArticlePmV1 ArticlePmV1Data {..} -> do
+    let domId = v1Id
+    domTitle <- Domain.titleFromText v1Title
+    domUri   <- Uri.toDomain v1Uri
+    domState <- readOrMappingError v1State
+    pure $ Domain.Article domId domTitle domUri domState v1Creation
+  _otherVersion -> toDomain $ migrate art
+
+------------------------------------------------------------------------
+-- Migration
+------------------------------------------------------------------------
+
+migrate :: ArticlePm -> ArticlePm
+migrate = \case
+  ArticlePmInit initData -> migrate $ ArticlePmV1 initData
+  ArticlePmV1   v1Data   -> ArticlePmV1 v1Data

--- a/src/Lib/Infra/Persistence/Model/Article.hs
+++ b/src/Lib/Infra/Persistence/Model/Article.hs
@@ -4,8 +4,9 @@ module Lib.Infra.Persistence.Model.Article
   , toDomain
   ) where
 
-import           Codec.Serialise.Class                                ( Serialise )
-import           Codec.Serialise.UUID                                 ( )
+import           Data.Aeson.Types                                     ( FromJSON
+                                                                      , ToJSON
+                                                                      )
 import           Data.Time.Clock                                      ( UTCTime )
 import           Prelude                                       hiding ( id
                                                                       , state
@@ -28,7 +29,7 @@ data ArticlePm = ArticlePm
   , creation :: !UTCTime
   }
   deriving stock Generic
-  deriving anyclass Serialise
+  deriving anyclass (FromJSON, ToJSON)
 
 fromDomain :: Article -> ArticlePm
 fromDomain domArt = do

--- a/src/Lib/Infra/Persistence/Model/ArticleList.hs
+++ b/src/Lib/Infra/Persistence/Model/ArticleList.hs
@@ -2,6 +2,7 @@ module Lib.Infra.Persistence.Model.ArticleList
   ( ArticleListPm
   , fromDomain
   , toDomain
+  , migrate
   ) where
 
 import qualified Data.Map.Strict                                     as Map
@@ -20,8 +21,19 @@ import           Lib.Infra.Persistence.Model.Shared                   ( modelLis
 
 type ArticleListPm = Map (Id Article) ArticlePm
 
+------------------------------------------------------------------------
+-- Mapper
+------------------------------------------------------------------------
+
 fromDomain :: ArticleList -> ArticleListPm
 fromDomain = Map.fromList . modelListFromDomain Article.fromDomain . Domain.toMap
 
 toDomain :: ArticleListPm -> Either AppErrorType ArticleList
 toDomain = Right . Domain.fromMap . Map.fromList <=< modelListToDomain Article.toDomain
+
+------------------------------------------------------------------------
+-- Migration
+------------------------------------------------------------------------
+
+migrate :: ArticleListPm -> ArticleListPm
+migrate = fmap Article.migrate

--- a/src/Lib/Infra/Persistence/Model/Capability.hs
+++ b/src/Lib/Infra/Persistence/Model/Capability.hs
@@ -4,8 +4,9 @@ module Lib.Infra.Persistence.Model.Capability
   , toDomain
   ) where
 
-import           Codec.Serialise.Class                                ( Serialise )
-import           Codec.Serialise.UUID                                 ( )
+import           Data.Aeson.Types                                     ( FromJSON
+                                                                      , ToJSON
+                                                                      )
 import           Data.Time.Clock                                      ( UTCTime )
 import           Prelude                                       hiding ( id )
 
@@ -24,7 +25,7 @@ data CapabilityPm = CapabilityPm
   , expirationDate  :: !(Maybe UTCTime)
   }
   deriving stock (Generic, Show)
-  deriving anyclass Serialise
+  deriving anyclass (FromJSON, ToJSON)
 
 instance Eq CapabilityPm where
   (==) a b = id a == id b

--- a/src/Lib/Infra/Persistence/Model/Capability.hs
+++ b/src/Lib/Infra/Persistence/Model/Capability.hs
@@ -1,11 +1,14 @@
 module Lib.Infra.Persistence.Model.Capability
-  ( CapabilityPm(..)
+  ( CapabilityPm
   , fromDomain
   , toDomain
+  , migrate
   ) where
 
 import           Data.Aeson.Types                                     ( FromJSON
-                                                                      , ToJSON
+                                                                      , ToJSON(..)
+                                                                      , defaultOptions
+                                                                      , genericToEncoding
                                                                       )
 import           Data.Time.Clock                                      ( UTCTime )
 import           Prelude                                       hiding ( id )
@@ -18,31 +21,52 @@ import           Lib.Domain.Id                                        ( Id )
 import           Lib.Infra.Persistence.Model.Id                       ( )
 import           Lib.Infra.Persistence.Model.Shared                   ( readOrMappingError )
 
-data CapabilityPm = CapabilityPm
-  { id              :: !(Id Capability)
-  , objectReference :: !Text
-  , petname         :: !(Maybe Text)
-  , expirationDate  :: !(Maybe UTCTime)
+data CapabilityPm
+  = CapabilityPmInit !CapabilityPmV1Data
+  | CapabilityPmV1 !CapabilityPmV1Data
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+instance ToJSON CapabilityPm where
+  toEncoding = genericToEncoding defaultOptions
+
+data CapabilityPmV1Data = CapabilityPmV1Data
+  { v1Id              :: !(Id Capability)
+  , v1ObjectReference :: !Text
+  , v1Petname         :: !(Maybe Text)
+  , v1ExpirationDate  :: !(Maybe UTCTime)
   }
   deriving stock (Generic, Show)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass FromJSON
 
-instance Eq CapabilityPm where
-  (==) a b = id a == id b
+instance ToJSON CapabilityPmV1Data where
+  toEncoding = genericToEncoding defaultOptions
 
-instance Ord CapabilityPm where
-  compare a b = compare (expirationDate a) (expirationDate b)
+------------------------------------------------------------------------
+-- Mapper
+------------------------------------------------------------------------
 
 fromDomain :: Capability -> CapabilityPm
 fromDomain domCap = do
-  let id              = Domain.id domCap
-      objectReference = show $ Domain.objectReference domCap
-      petname         = Domain.petname domCap
-      expirationDate  = Domain.expirationDate domCap
-  CapabilityPm { .. }
+  let v1Id              = Domain.id domCap
+      v1ObjectReference = show $ Domain.objectReference domCap
+      v1Petname         = Domain.petname domCap
+      v1ExpirationDate  = Domain.expirationDate domCap
+  CapabilityPmV1 $ CapabilityPmV1Data { .. }
 
 toDomain :: CapabilityPm -> Either AppErrorType Capability
-toDomain CapabilityPm {..} = do
-  let domId = id
-  domObjectReference <- readOrMappingError objectReference
-  pure $ Domain.Capability domId domObjectReference petname expirationDate
+toDomain cap = case cap of
+  CapabilityPmV1 CapabilityPmV1Data {..} -> do
+    let domId = v1Id
+    domObjectReference <- readOrMappingError v1ObjectReference
+    pure $ Domain.Capability domId domObjectReference v1Petname v1ExpirationDate
+  _otherVersion -> toDomain $ migrate cap
+
+------------------------------------------------------------------------
+-- Migration
+------------------------------------------------------------------------
+
+migrate :: CapabilityPm -> CapabilityPm
+migrate = \case
+  CapabilityPmInit initData -> migrate $ CapabilityPmV1 initData
+  CapabilityPmV1   v1Data   -> CapabilityPmV1 v1Data

--- a/src/Lib/Infra/Persistence/Model/CapabilityList.hs
+++ b/src/Lib/Infra/Persistence/Model/CapabilityList.hs
@@ -2,6 +2,7 @@ module Lib.Infra.Persistence.Model.CapabilityList
   ( CapabilityListPm
   , fromDomain
   , toDomain
+  , migrate
   ) where
 
 import qualified Data.Map.Strict                                     as Map
@@ -20,8 +21,19 @@ import           Lib.Infra.Persistence.Model.Shared                   ( modelLis
 
 type CapabilityListPm = Map (Id Capability) CapabilityPm
 
+------------------------------------------------------------------------
+-- Mapper
+------------------------------------------------------------------------
+
 fromDomain :: CapabilityList -> CapabilityListPm
 fromDomain = Map.fromList . modelListFromDomain Capability.fromDomain . Domain.toMap
 
 toDomain :: CapabilityListPm -> Either AppErrorType CapabilityList
 toDomain = Right . Domain.fromMap . Map.fromList <=< modelListToDomain Capability.toDomain
+
+------------------------------------------------------------------------
+-- Migration
+------------------------------------------------------------------------
+
+migrate :: CapabilityListPm -> CapabilityListPm
+migrate = fmap Capability.migrate

--- a/src/Lib/Infra/Persistence/Model/Collection.hs
+++ b/src/Lib/Infra/Persistence/Model/Collection.hs
@@ -1,23 +1,79 @@
 module Lib.Infra.Persistence.Model.Collection
-  ( CollectionPm(..)
+  ( CollectionPm
   , mkCollection
+  , getArticleList
+  , updateArticleList
+  , getCapabilityList
+  , updateCapabilityList
+  , migrate
   ) where
 
 import qualified Data.Map.Strict                                     as Map
 
 import           Data.Aeson.Types                                     ( FromJSON
-                                                                      , ToJSON
+                                                                      , ToJSON(..)
+                                                                      , defaultOptions
+                                                                      , genericToEncoding
                                                                       )
+
+import qualified Lib.Infra.Persistence.Model.ArticleList             as ArticleList
+import qualified Lib.Infra.Persistence.Model.CapabilityList          as CapabilityList
 
 import           Lib.Infra.Persistence.Model.ArticleList              ( ArticleListPm )
 import           Lib.Infra.Persistence.Model.CapabilityList           ( CapabilityListPm )
 
-data CollectionPm = CollectionPm
-  { articleList    :: !ArticleListPm
-  , capabilityList :: !CapabilityListPm
+data CollectionPm
+  = CollectionPmInit !CollectionPmV1Data
+  | CollectionPmV1 !CollectionPmV1Data
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+instance ToJSON CollectionPm where
+  toEncoding = genericToEncoding defaultOptions
+
+data CollectionPmV1Data = CollectionPmV1Data
+  { v1ArticleList    :: !ArticleListPm
+  , v1CapabilityList :: !CapabilityListPm
   }
   deriving stock Generic
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass FromJSON
+
+instance ToJSON CollectionPmV1Data where
+  toEncoding = genericToEncoding defaultOptions
 
 mkCollection :: CollectionPm
-mkCollection = CollectionPm Map.empty Map.empty
+mkCollection = CollectionPmV1 $ CollectionPmV1Data Map.empty Map.empty
+
+getArticleList :: CollectionPm -> ArticleListPm
+getArticleList col = case col of
+  CollectionPmV1 v1Data -> v1ArticleList v1Data
+  _otherVersion         -> getArticleList $ migrate col
+
+updateArticleList :: ArticleListPm -> CollectionPm -> CollectionPm
+updateArticleList arts col = case col of
+  CollectionPmV1 v1Data -> CollectionPmV1 v1Data { v1ArticleList = arts }
+  _otherVersion         -> updateArticleList arts $ migrate col
+
+getCapabilityList :: CollectionPm -> CapabilityListPm
+getCapabilityList col = case col of
+  CollectionPmV1 v1Data -> v1CapabilityList v1Data
+  _otherVersion         -> getCapabilityList $ migrate col
+
+updateCapabilityList :: CapabilityListPm -> CollectionPm -> CollectionPm
+updateCapabilityList caps col = case col of
+  CollectionPmV1 v1Data -> CollectionPmV1 v1Data { v1CapabilityList = caps }
+  _otherVersion         -> updateCapabilityList caps $ migrate col
+
+------------------------------------------------------------------------
+-- Migration
+------------------------------------------------------------------------
+
+migrate :: CollectionPm -> CollectionPm
+migrate = \case
+  CollectionPmInit initData -> migrate $ CollectionPmV1 initData
+  CollectionPmV1   v1Data   -> CollectionPmV1 $ migrateV1Data v1Data
+
+migrateV1Data :: CollectionPmV1Data -> CollectionPmV1Data
+migrateV1Data colData@CollectionPmV1Data {..} = colData { v1ArticleList    = ArticleList.migrate v1ArticleList
+                                                        , v1CapabilityList = CapabilityList.migrate v1CapabilityList
+                                                        }

--- a/src/Lib/Infra/Persistence/Model/Collection.hs
+++ b/src/Lib/Infra/Persistence/Model/Collection.hs
@@ -5,7 +5,9 @@ module Lib.Infra.Persistence.Model.Collection
 
 import qualified Data.Map.Strict                                     as Map
 
-import           Codec.Serialise.Class                                ( Serialise )
+import           Data.Aeson.Types                                     ( FromJSON
+                                                                      , ToJSON
+                                                                      )
 
 import           Lib.Infra.Persistence.Model.ArticleList              ( ArticleListPm )
 import           Lib.Infra.Persistence.Model.CapabilityList           ( CapabilityListPm )
@@ -15,7 +17,7 @@ data CollectionPm = CollectionPm
   , capabilityList :: !CapabilityListPm
   }
   deriving stock Generic
-  deriving anyclass Serialise
+  deriving anyclass (FromJSON, ToJSON)
 
 mkCollection :: CollectionPm
 mkCollection = CollectionPm Map.empty Map.empty

--- a/src/Lib/Infra/Persistence/Model/Id.hs
+++ b/src/Lib/Infra/Persistence/Model/Id.hs
@@ -2,11 +2,17 @@
 
 module Lib.Infra.Persistence.Model.Id where
 
-import           Codec.Serialise.Class                                ( Serialise )
-import           Codec.Serialise.UUID                                 ( )
+import           Data.Aeson.Types                                     ( FromJSON
+                                                                      , FromJSONKey
+                                                                      , ToJSON
+                                                                      , ToJSONKey
+                                                                      )
 import           Data.UUID                                            ( UUID )
 
 import qualified Lib.Domain.Id                                       as Domain
 import           Lib.Domain.Id                                        ( Id )
 
-deriving via UUID instance Serialise (Id a)
+deriving via UUID instance FromJSON (Id a)
+deriving via UUID instance FromJSONKey (Id a)
+deriving via UUID instance ToJSON (Id a)
+deriving via UUID instance ToJSONKey (Id a)

--- a/src/Lib/Infra/Repo/ArticleList.hs
+++ b/src/Lib/Infra/Repo/ArticleList.hs
@@ -38,7 +38,7 @@ saveAll colId updates = commit colId action
     collection  <- File.load colId id
     articles    <- articlesFromCollection collection
     newArticles <- throwOnError $ foldlM (&) articles updates
-    File.save colId $ collection { ColPm.articleList = ArtListPm.fromDomain newArticles }
+    File.save colId $ ColPm.updateArticleList (ArtListPm.fromDomain newArticles) collection
 
 articlesFromCollection :: WithError m => CollectionPm -> m ArticleList
-articlesFromCollection = throwOnError . ArtListPm.toDomain . ColPm.articleList
+articlesFromCollection = throwOnError . ArtListPm.toDomain . ColPm.getArticleList

--- a/src/Lib/Infra/Repo/CapabilityList.hs
+++ b/src/Lib/Infra/Repo/CapabilityList.hs
@@ -38,7 +38,7 @@ saveAll colId updates = commit colId action
     collection      <- File.load colId id
     capabilities    <- capabilitiesFromCollection collection
     newCapabilities <- throwOnError $ foldlM (&) capabilities updates
-    File.save colId $ collection { ColPm.capabilityList = CapListPm.fromDomain newCapabilities }
+    File.save colId $ ColPm.updateCapabilityList (CapListPm.fromDomain newCapabilities) collection
 
 capabilitiesFromCollection :: WithError m => CollectionPm -> m CapabilityList
-capabilitiesFromCollection = throwOnError . CapListPm.toDomain . ColPm.capabilityList
+capabilitiesFromCollection = throwOnError . CapListPm.toDomain . ColPm.getCapabilityList

--- a/src/Lib/Infra/Repo/Collection.hs
+++ b/src/Lib/Infra/Repo/Collection.hs
@@ -21,5 +21,5 @@ createCollection :: (WithFile env m) => Id Collection -> Id Capability -> Capabi
 createCollection colId capId cap = File.init colId collectionPm
  where
   collectionPm = do
-    let newCapList = Map.insert capId (CapPm.fromDomain cap) . ColPm.capabilityList $ ColPm.mkCollection
-    ColPm.mkCollection { ColPm.capabilityList = newCapList }
+    let newCapList = Map.insert capId (CapPm.fromDomain cap) . ColPm.getCapabilityList $ ColPm.mkCollection
+    ColPm.updateCapabilityList newCapList ColPm.mkCollection

--- a/src/Lib/Ui/Cli/Handler.hs
+++ b/src/Lib/Ui/Cli/Handler.hs
@@ -14,16 +14,18 @@ import           Lib.Infra.Monad                                      ( AppEnv )
 
 data CliAction
   = RunServer
+  | Migrate
   | Collection CollectionCommand
 
 data CollectionCommand = NewCollection
 
 commandHandler :: (CollectionRepo m, MonadRandom m, MonadIO m) => CliAction -> m ()
 commandHandler RunServer                = pure ()
+commandHandler Migrate                  = pure ()
 commandHandler (Collection colCommands) = case colCommands of
   NewCollection -> do
     acc <- Command.createCollection
-    putStrLn $ "Accesstoken: " <> toString acc
+    print $ "Accesstoken: " <> acc
 
 runCli :: AppEnv -> CliAction -> IO ()
 runCli env = runAppLogIO_ env . commandHandler

--- a/src/Lib/Ui/Cli/Handler.hs
+++ b/src/Lib/Ui/Cli/Handler.hs
@@ -15,13 +15,13 @@ import           Lib.Infra.Monad                                      ( AppEnv )
 data CliAction
   = RunServer
   | Migrate
-  | Collection CollectionCommand
+  | Collection !CollectionCommand
 
 data CollectionCommand = NewCollection
 
 commandHandler :: (CollectionRepo m, MonadRandom m, MonadIO m) => CliAction -> m ()
-commandHandler RunServer                = pure ()
-commandHandler Migrate                  = pure ()
+commandHandler RunServer                = pass
+commandHandler Migrate                  = pass
 commandHandler (Collection colCommands) = case colCommands of
   NewCollection -> do
     acc <- Command.createCollection

--- a/src/Lib/Ui/Web/Page/CollectionOverview.hs
+++ b/src/Lib/Ui/Web/Page/CollectionOverview.hs
@@ -16,7 +16,6 @@ import           Servant                                              ( Link
 
 import qualified Lib.Domain.Authorization                            as Authz
 import qualified Lib.Domain.Capability                               as Cap
-import qualified Lib.Infra.Persistence.Model.Capability              as CapPm
 import qualified Lib.Ui.Web.Page.Layout                              as Layout
 import qualified Lib.Ui.Web.Page.Static                              as Static
 import qualified Lib.Ui.Web.Page.ViewModel.Capability                as CapVm
@@ -96,7 +95,7 @@ getUnlockLinks colId curTime = do
   filterF cap = isStillValid cap && isViewArticles cap
 
   isStillValid :: Capability -> Bool
-  isStillValid = isJust . capStillValid curTime . CapPm.fromDomain
+  isStillValid = isJust . capStillValid curTime
 
   isViewArticles :: Capability -> Bool
   isViewArticles = isRight . Authz.canViewArticles . Cap.objectReference

--- a/src/Migration.hs
+++ b/src/Migration.hs
@@ -1,0 +1,22 @@
+module Migration
+  ( migrate
+  ) where
+
+
+import           UnliftIO.Directory                                   ( listDirectory )
+
+import qualified Lib.Infra.Persistence.Model.Collection              as Collection
+
+import           Lib.Infra.Persistence.File                           ( decodeFile
+                                                                      , encodeFile
+                                                                      )
+
+migrate :: (MonadIO m) => FilePath -> m ()
+migrate fp = do
+  print @Text "Starting migration."
+  collectionPaths <- (fp <>) <<$>> listDirectory fp
+  traverse_ migrateCollection collectionPaths
+  print @Text "Migration done."
+
+migrateCollection :: (MonadIO m) => FilePath -> m ()
+migrateCollection fp = encodeFile fp . Collection.migrate =<< decodeFile fp

--- a/test/Test/App/Command.hs
+++ b/test/Test/App/Command.hs
@@ -121,7 +121,7 @@ commandMockedSpecs = describe "Lib.App.Command" $ do
       let objRef  = objRefWithAllArticlesPerms
           command = Command.DeleteArticle { .. }
       void . runTestApp env $ Command.deleteArticle command
-      let predicate = either (const True) (const False) . ArtList.lookup artId
+      let predicate = isLeft . ArtList.lookup artId
       env & ArtRepo.loadAll colId `satisfies` predicate
 
     it "fails when deleting an article with insufficent permissions" $ do
@@ -156,7 +156,7 @@ commandMockedSpecs = describe "Lib.App.Command" $ do
       let objRef  = objRefWithAllOverviewPerms
           command = Command.DeleteUnlockLink { .. }
       void . runTestApp env $ Command.deleteUnlockLink command
-      let predicate = either (const True) (const False) . CapList.lookup capId
+      let predicate = isLeft . CapList.lookup capId
       env & CapRepo.loadAll colId `satisfies` predicate
 
     it "fails when deleting an unlock link with insufficent permissions" $ do
@@ -190,7 +190,7 @@ commandMockedSpecs = describe "Lib.App.Command" $ do
       let objRef  = objRefWithAllOverviewPerms
           command = Command.DeleteShareUnlockLinks { .. }
       void . runTestApp env $ Command.deleteShareUnlockLinks command
-      let predicate = either (const True) (const False) . CapList.lookup capId
+      let predicate = isLeft . CapList.lookup capId
       env & CapRepo.loadAll colId `satisfies` predicate
 
     it "fails when deleting an shared unlock link with insufficent permissions" $ do
@@ -224,7 +224,7 @@ commandMockedSpecs = describe "Lib.App.Command" $ do
       let objRef  = objRefWithAllArticlesPerms
           command = Command.DeleteShareArticleList { .. }
       void . runTestApp env $ Command.deleteShareArticleList command
-      let predicate = either (const True) (const False) . CapList.lookup capId
+      let predicate = isLeft . CapList.lookup capId
       env & CapRepo.loadAll colId `satisfies` predicate
 
     it "fails when deleting a shared article list link with insufficent permissions" $ do
@@ -261,7 +261,7 @@ commandMockedSpecs = describe "Lib.App.Command" $ do
       let objRef  = objRefWithAllArticlePerms artId
           command = Command.DeleteShareArticle { .. }
       void . runTestApp env $ Command.deleteShareArticle command
-      let predicate = either (const True) (const False) . CapList.lookup capId
+      let predicate = isLeft . CapList.lookup capId
       env & CapRepo.loadAll colId `satisfies` predicate
 
     it "fails when deleting a shared article link with insufficent permissions" $ do

--- a/test/Test/Infra/Repo/ArticleList.hs
+++ b/test/Test/Infra/Repo/ArticleList.hs
@@ -32,7 +32,7 @@ testSaveAll _colId updates = do
   collection    <- readIORef collectionRef
   articles      <- articlesFromCollection collection
   newArticles   <- fmap ArtListPm.fromDomain . throwOnError $ foldlM (&) articles updates
-  writeIORef collectionRef $ collection { ColPm.articleList = newArticles }
+  writeIORef collectionRef $ ColPm.updateArticleList newArticles collection
 
 articlesFromCollection :: WithError m => CollectionPm -> m ArticleList
-articlesFromCollection = throwOnError . ArtListPm.toDomain . ColPm.articleList
+articlesFromCollection = throwOnError . ArtListPm.toDomain . ColPm.getArticleList

--- a/test/Test/Infra/Repo/CapabilityList.hs
+++ b/test/Test/Infra/Repo/CapabilityList.hs
@@ -33,7 +33,7 @@ testSaveAll _colId updates = do
   collection      <- readIORef collectionRef
   capabilities    <- capabilitiesFromCollection collection
   newCapabilities <- fmap CapListPm.fromDomain . throwOnError $ foldlM (&) capabilities updates
-  writeIORef collectionRef $ collection { ColPm.capabilityList = newCapabilities }
+  writeIORef collectionRef $ ColPm.updateCapabilityList newCapabilities collection
 
 capabilitiesFromCollection :: WithError m => CollectionPm -> m CapabilityList
-capabilitiesFromCollection = throwOnError . CapListPm.toDomain . ColPm.capabilityList
+capabilitiesFromCollection = throwOnError . CapListPm.toDomain . ColPm.getCapabilityList

--- a/test/Test/Infra/Repo/Collection.hs
+++ b/test/Test/Infra/Repo/Collection.hs
@@ -24,5 +24,5 @@ testCreateCollection
 testCreateCollection _colId capId cap = flip writeIORef collectionPm =<< grab @CollectionState
  where
   collectionPm = do
-    let capabilities = Map.insert capId (CapPm.fromDomain cap) . ColPm.capabilityList $ ColPm.mkCollection
-    ColPm.mkCollection { ColPm.capabilityList = capabilities }
+    let capabilities = Map.insert capId (CapPm.fromDomain cap) . ColPm.getCapabilityList $ ColPm.mkCollection
+    ColPm.updateCapabilityList capabilities ColPm.mkCollection

--- a/test/Test/Ui/Web/Controller/Shared.hs
+++ b/test/Test/Ui/Web/Controller/Shared.hs
@@ -13,7 +13,6 @@ module Test.Ui.Web.Controller.Shared
   ) where
 
 import qualified Data.ByteString.Char8                               as B
-import qualified Data.ByteString.Lazy                                as BL
 import qualified Test.Hspec.Wai                                      as Test
 
 import           Network.HTTP.Types                                   ( methodPost )
@@ -140,5 +139,5 @@ postCreateUnlockLink = postForm unlockLinkRoute . unlockLinkForm
   unlockLinkRoute = linkAsByteString $ fieldLink Route.createUnlockLink
 
 getOverviewPage :: Accesstoken -> WaiSession st ByteString
-getOverviewPage acc = BL.toStrict . simpleBody <$> Test.get (overviewRoute acc)
+getOverviewPage acc = toStrict . simpleBody <$> Test.get (overviewRoute acc)
   where overviewRoute = linkAsByteString . fieldLink Route.overviewPage . Just


### PR DESCRIPTION
This PR extends the persistence models and the access token DTO with migration logic.
A new CLI command is also added to migrate all stored collections at once.

The serialization format is also changed from CBOR to JSON.
It’s easier to debug, more accessible, and more reusable for other use cases.

Closes #26