### PR TITLE
Remove `Ord` instance for capabilities

### DIFF
--- a/src/Lib/Domain/Capability.hs
+++ b/src/Lib/Domain/Capability.hs
@@ -68,9 +68,6 @@ data Capability = Capability
 instance Eq Capability where
   (==) (Capability aId _ _ _) (Capability bId _ _ _) = aId == bId
 
-instance Ord Capability where
-  compare a b = compare (expirationDate a) (expirationDate b)
-
 mkCapability :: Id Capability -> ObjectReference -> Maybe Text -> Maybe UTCTime -> Capability
 mkCapability id objectReference mPetname expirationDate = Capability { .. }
  where

--- a/src/Lib/Ui/Web/Page/CollectionOverview.hs
+++ b/src/Lib/Ui/Web/Page/CollectionOverview.hs
@@ -86,7 +86,7 @@ getUnlockLinks colId curTime = do
   mapToSeq = Seq.fromList . Map.toList
 
   filterAndSortCaps :: Seq (a, Capability) -> Seq (a, Capability)
-  filterAndSortCaps = Seq.sortOn snd . Seq.filter (filterF . snd)
+  filterAndSortCaps = Seq.sortOn (Cap.expirationDate . snd) . Seq.filter (filterF . snd)
 
   toUnlockLink :: (Id Capability, Capability) -> UnlockLinkVm
   toUnlockLink = uncurry (UnlockLink.fromDomain colId)

--- a/test/Test/Domain/Capability.hs
+++ b/test/Test/Domain/Capability.hs
@@ -2,10 +2,6 @@ module Test.Domain.Capability
   ( capabilitySpec
   ) where
 
-import           Data.Time.Clock                                      ( UTCTime
-                                                                      , addUTCTime
-                                                                      , secondsToNominalDiffTime
-                                                                      )
 import           Prelude                                       hiding ( id )
 import           Test.Hspec                                           ( Spec
                                                                       , describe
@@ -19,8 +15,7 @@ import qualified Lib.Domain.Capability                               as Capabili
 import           Lib.Domain.Capability                                ( Capability
                                                                       , ObjectReference
                                                                       )
-import           Test.Domain.Shared                                   ( getCurrentTime
-                                                                      , getRandomId
+import           Test.Domain.Shared                                   ( getRandomId
                                                                       , objRefWithAllArticlePerms
                                                                       )
 
@@ -36,13 +31,6 @@ capabilitySpec = describe "Lib.Domain.Capability" $ do
     cap1 <- capabilityWithObjRef Capability.defaultOverviewRef
     cap2 <- capabilityWithObjRef Capability.defaultOverviewRef
     cap1 `shouldSatisfy` (/= cap2)
-
-  it "capabilities with later expiration dates are greater than capabilities with earlier ones" $ do
-    date1 <- getCurrentTime
-    cap1  <- capabilityWithNewExpDate date1
-    let plusOneHour = secondsToNominalDiffTime 3600
-    cap2 <- capabilityWithNewExpDate $ addUTCTime plusOneHour date1
-    cap2 `shouldSatisfy` (> cap1)
 
   it "'mkCapability' does not accept empty petnames" $ do
     capId <- getRandomId
@@ -114,12 +102,4 @@ capabilityWithObjRef objectReference = do
   id <- getRandomId
   let petname        = Nothing
       expirationDate = Nothing
-  pure $ Capability.Capability { .. }
-
-capabilityWithNewExpDate :: (MonadIO m) => UTCTime -> m Capability
-capabilityWithNewExpDate expDate = do
-  id <- getRandomId
-  let objectReference = Capability.defaultOverviewRef
-      petname         = Nothing
-      expirationDate  = Just expDate
   pure $ Capability.Capability { .. }


### PR DESCRIPTION
There is no canonical implementation for this. Sometimes comparing the expiration dates makes sense. But comparing object references somehow could also be a valid option. Let’s remove the instance for now.