### PR TITLE
Remove expired capabilities

### DIFF
--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -40,6 +40,7 @@ library
         Lib.Infra.Error
         Lib.Infra.Log
         Lib.Infra.Monad
+        Lib.Infra.Persistence.Cleanup
         Lib.Infra.Persistence.File
         Lib.Infra.Persistence.Model.Article
         Lib.Infra.Persistence.Model.ArticleList

--- a/src/Lib/Domain/CapabilityList.hs
+++ b/src/Lib/Domain/CapabilityList.hs
@@ -9,6 +9,7 @@ module Lib.Domain.CapabilityList
   , removeShareArticleList
   , addShareArticle
   , removeShareArticle
+  , removeExpiredCapabilities
   , mkCapabilityList
   , fromMap
   , toMap
@@ -16,6 +17,10 @@ module Lib.Domain.CapabilityList
   ) where
 
 import qualified Data.Map.Strict                                     as Map
+
+import           Data.Time.Clock                                      ( UTCTime )
+
+import qualified Lib.Domain.Capability                               as Cap
 
 import           Lib.Domain.Authorization                             ( CreateUnlockLinksPerm
                                                                       , DeleteUnlockLinksPerm
@@ -49,6 +54,14 @@ deleted, because delete is idempotent.
  -}
 removeUnlockLink :: RemoveCapability DeleteUnlockLinksPerm
 removeUnlockLink _perm = removeCapability
+
+removeExpiredCapabilities :: DeleteUnlockLinksPerm -> UTCTime -> CapabilityList -> CapabilityList
+removeExpiredCapabilities _perm curTime = wrapMap $ Map.filter unexpiredCap
+ where
+  unexpiredCap :: Capability -> Bool
+  unexpiredCap cap = case Cap.expirationDate cap of
+    Nothing      -> True
+    Just expDate -> expDate > curTime
 
 addShareUnlockLinks :: AddCapability ShareUnlockLinksPerm
 addShareUnlockLinks _perm = addCapability

--- a/src/Lib/Domain/Id.hs
+++ b/src/Lib/Domain/Id.hs
@@ -3,11 +3,12 @@ module Lib.Domain.Id
   , mkNilId
   , fromUuid
   , toUuid
+  , fromText
   ) where
 
-import           Data.UUID                                            ( UUID
-                                                                      , nil
-                                                                      )
+import qualified Data.UUID                                           as UUID
+
+import           Data.UUID                                            ( UUID )
 
 newtype Id a = Id {unId :: UUID}
   deriving (Eq, Ord, Read, Show) via UUID
@@ -16,10 +17,13 @@ instance ToText (Id a) where
   toText = show . unId
 
 mkNilId :: Id a
-mkNilId = coerce nil
+mkNilId = coerce UUID.nil
 
 fromUuid :: UUID -> Id a
 fromUuid = coerce
 
 toUuid :: Id a -> UUID
 toUuid = coerce
+
+fromText :: Text -> Maybe (Id a)
+fromText = coerce . UUID.fromText

--- a/src/Lib/Domain/Repo/CapabilityList.hs
+++ b/src/Lib/Domain/Repo/CapabilityList.hs
@@ -4,6 +4,7 @@ module Lib.Domain.Repo.CapabilityList
   , save
   , addUnlockLink
   , removeUnlockLink
+  , removeExpiredCapabilities
   , addShareUnlockLinks
   , removeShareUnlockLinks
   , addShareArticleList
@@ -11,6 +12,8 @@ module Lib.Domain.Repo.CapabilityList
   , addShareArticle
   , removeShareArticle
   ) where
+
+import           Data.Time.Clock                                      ( UTCTime )
 
 import qualified Lib.Domain.CapabilityList                           as CapList
 
@@ -41,6 +44,9 @@ addUnlockLink = CapList.addUnlockLink
 
 removeUnlockLink :: DeleteUnlockLinksPerm -> Id Capability -> CapabilityListAction
 removeUnlockLink perm capId = pure . CapList.removeUnlockLink perm capId
+
+removeExpiredCapabilities :: DeleteUnlockLinksPerm -> UTCTime -> CapabilityListAction
+removeExpiredCapabilities perm curTime = pure . CapList.removeExpiredCapabilities perm curTime
 
 addShareUnlockLinks :: ShareUnlockLinksPerm -> Id Capability -> Capability -> CapabilityListAction
 addShareUnlockLinks = CapList.addShareUnlockLinks

--- a/src/Lib/Infra/Persistence/Cleanup.hs
+++ b/src/Lib/Infra/Persistence/Cleanup.hs
@@ -1,0 +1,28 @@
+module Lib.Infra.Persistence.Cleanup
+  ( removeExpiredCapabilitiesFromCollections
+  ) where
+
+import qualified Lib.App.Command                                     as Command
+import qualified Lib.Domain.Capability                               as Cap
+import qualified Lib.Infra.Persistence.File                          as File
+
+import           Lib.App.Port                                         ( MonadTime )
+import           Lib.Domain.Capability                                ( ObjectReference )
+import           Lib.Domain.Collection                                ( Collection )
+import           Lib.Domain.Id                                        ( Id )
+import           Lib.Domain.Repo.CapabilityList                       ( CapabilityListRepo )
+import           Lib.Infra.Error                                      ( WithError
+                                                                      , throwOnErrorM
+                                                                      )
+import           Lib.Infra.Persistence.File                           ( WithFile )
+
+removeExpiredCapabilitiesFromCollections :: (CapabilityListRepo m, MonadTime m, WithError m, WithFile env m) => m ()
+removeExpiredCapabilitiesFromCollections = do
+  colIds <- File.allIdsInPath
+  traverse_ (removeExpiredCapabilitiesFromCollection objRef) colIds
+  where objRef = Cap.OverviewRef $ Cap.mkOverviewPerms False False True False
+
+removeExpiredCapabilitiesFromCollection
+  :: (CapabilityListRepo m, MonadTime m, WithError m) => ObjectReference -> Id Collection -> m ()
+removeExpiredCapabilitiesFromCollection objRef colId = throwOnErrorM $ Command.removeExpiredCapabilities command
+  where command = Command.RemoveExpiredCapabilities { .. }

--- a/src/Lib/Infra/Persistence/File.hs
+++ b/src/Lib/Infra/Persistence/File.hs
@@ -6,28 +6,39 @@ module Lib.Infra.Persistence.File
   , save
   , decodeFile
   , encodeFile
+  , allIdsInPath
   ) where
 
 
 import qualified Codec.Compression.GZip                              as GZip
+import qualified Data.Sequence                                       as Seq
+import qualified Data.Text                                           as T
 
 import           Data.Aeson                                           ( decode
                                                                       , encode
                                                                       )
-import           Prelude                                       hiding ( init )
-import           UnliftIO                                             ( MonadUnliftIO )
-import           UnliftIO.Directory                                   ( doesFileExist )
-import           UnliftIO.IO.File                                     ( writeBinaryFileDurableAtomic )
-
 import           Data.Aeson.Types                                     ( FromJSON
                                                                       , ToJSON
                                                                       )
+import           Prelude                                       hiding ( init )
+import           UnliftIO                                             ( MonadUnliftIO )
+import           UnliftIO.Directory                                   ( doesFileExist
+                                                                      , listDirectory
+                                                                      )
+import           UnliftIO.IO.File                                     ( writeBinaryFileDurableAtomic )
+
+import qualified Lib.Domain.Id                                       as Id
+
 import           Lib.App.Env                                          ( DataPath
                                                                       , Has
                                                                       , grab
                                                                       )
 import           Lib.Domain.Collection                                ( Collection )
+import           Lib.Domain.Error                                     ( serverError )
 import           Lib.Domain.Id                                        ( Id )
+import           Lib.Infra.Error                                      ( WithError
+                                                                      , throwOnNothing
+                                                                      )
 import           Lib.Infra.Persistence.Model.Collection               ( CollectionPm )
 
 type WithFile env m = (MonadReader env m, Has DataPath env, MonadUnliftIO m)
@@ -59,7 +70,29 @@ encodeFile :: (ToJSON a, MonadIO m) => FilePath -> a -> m ()
 encodeFile fp = writeBinaryFileDurableAtomic fp . toStrict . GZip.compress . encode
 {-# INLINE encodeFile #-}
 
+allIdsInPath :: (WithError m, WithFile env m) => m (Seq (Id Collection))
+allIdsInPath = do
+  dataPath <- grab @DataPath
+  paths    <- (dataPath <>) <<$>> listDirectory dataPath
+  traverse pathToId $ Seq.fromList paths
+
 idToPath :: (WithFile env m) => Id Collection -> m FilePath
 idToPath colId = do
   dataPath <- grab @DataPath
-  pure $ dataPath <> show colId <> ".json.gz"
+  pure $ dataPath <> show colId <> fileEnding
+
+pathToId :: (WithError m, WithFile env m) => FilePath -> m (Id Collection)
+pathToId fp = do
+  dataPath           <- grab @DataPath
+  strippedSuffixPath <- throwOnNothing invalidSuffixError strippedSuffixPathM
+  strippedPath       <- throwOnNothing invalidPrefixError $ strippedPathM dataPath strippedSuffixPath
+  throwOnNothing invalidNameError $ Id.fromText strippedPath
+ where
+  strippedSuffixPathM = T.stripSuffix (toText fileEnding) (toText fp)
+  strippedPathM prefix = T.stripPrefix (toText prefix)
+  invalidSuffixError = serverError "Could not convert filepath to collection id"
+  invalidPrefixError = serverError "Could not strip data path prefix"
+  invalidNameError   = serverError "Filepath is not a valid collection id"
+
+fileEnding :: String
+fileEnding = ".json.gz"

--- a/src/Lib/Infra/Persistence/Server.hs
+++ b/src/Lib/Infra/Persistence/Server.hs
@@ -13,6 +13,7 @@ import           Lib.Infra.Log                                        ( pattern 
                                                                       , runAppLogIO_
                                                                       )
 import           Lib.Infra.Monad                                      ( AppEnv )
+import           Lib.Infra.Persistence.Cleanup                        ( removeExpiredCapabilitiesFromCollections )
 import           Lib.Infra.Persistence.Queue                          ( WithQueue
                                                                       , fetchUpdates
                                                                       , processUpdates

--- a/src/Lib/Infra/Persistence/Server.hs
+++ b/src/Lib/Infra/Persistence/Server.hs
@@ -4,9 +4,15 @@ module Lib.Infra.Persistence.Server
 
 import qualified Data.Map.Strict                                     as Map
 
-import           UnliftIO.Async                                       ( race_ )
+import           UnliftIO.Async                                       ( conc
+                                                                      , runConc
+                                                                      )
+import           UnliftIO.Concurrent                                  ( threadDelay )
 
 import           Lib.App.Env                                          ( envWriteQueue )
+import           Lib.App.Port                                         ( MonadTime )
+import           Lib.Domain.Repo.CapabilityList                       ( CapabilityListRepo )
+import           Lib.Infra.Error                                      ( WithError )
 import           Lib.Infra.Log                                        ( pattern E
                                                                       , WithLog
                                                                       , log
@@ -14,17 +20,30 @@ import           Lib.Infra.Log                                        ( pattern 
                                                                       )
 import           Lib.Infra.Monad                                      ( AppEnv )
 import           Lib.Infra.Persistence.Cleanup                        ( removeExpiredCapabilitiesFromCollections )
+import           Lib.Infra.Persistence.File                           ( WithFile )
 import           Lib.Infra.Persistence.Queue                          ( WithQueue
                                                                       , fetchUpdates
                                                                       , processUpdates
                                                                       )
 
-server :: (WithLog env m, WithQueue env m) => m ()
+server :: (CapabilityListRepo m, MonadTime m, WithError m, WithFile env m, WithLog env m, WithQueue env m) => m ()
 server = do
   commandQueue      <- envWriteQueue
   workerQueueMapVar <- newTVarIO Map.empty
-  race_ (fetchUpdates commandQueue workerQueueMapVar) (processUpdates workerQueueMapVar)
+  void $ runJobs commandQueue workerQueueMapVar
   log E "Persistence server finished unexpectedly"
+ where
+  runJobs commandQueue workerQueueMapVar =
+    runConc
+      $   (,,)
+      <$> conc (fetchUpdates commandQueue workerQueueMapVar)
+      <*> (conc (processUpdates workerQueueMapVar) <|> conc cleanup)
+
+cleanup :: (CapabilityListRepo m, MonadTime m, WithError m, WithFile env m) => m Void
+cleanup = infinitely $ do
+  removeExpiredCapabilitiesFromCollections
+  threadDelay $ timeoutInMinutes 60
+  where timeoutInMinutes minutes = 1000 * 1000 * 60 * minutes
 
 persistenceApp :: AppEnv -> IO ()
 persistenceApp env = runAppLogIO_ env server

--- a/test/Test/Domain/Id.hs
+++ b/test/Test/Domain/Id.hs
@@ -2,11 +2,13 @@ module Test.Domain.Id
   ( idProps
   ) where
 
+import qualified Data.UUID                                           as UUID
 import qualified Data.UUID.V4                                        as UUID
 
 import           Hedgehog                                             ( (===)
                                                                       , Group(Group)
                                                                       , Property
+                                                                      , failure
                                                                       , property
                                                                       )
 
@@ -15,7 +17,13 @@ import qualified Lib.Domain.Id                                       as Id
 import           Test.Domain.Shared                                   ( getRandomId )
 
 idProps :: Group
-idProps = Group "Lib.Domain.Id" [("toUuid . fromUuid ≡ True", uuidToId), ("fromUuid . toUuid ≡ True", idToUuid)]
+idProps = Group
+  "Lib.Domain.Id"
+  [ ("toUuid . fromUuid ≡ True", uuidToId)
+  , ("fromUuid . toUuid ≡ True", idToUuid)
+  , ("toText . fromText ≡ True", textToId)
+  , ("fromText . toText ≡ True", idToText)
+  ]
 
 uuidToId :: Property
 uuidToId = property $ do
@@ -28,3 +36,18 @@ idToUuid = property $ do
   randId <- getRandomId
   let randUuid = Id.toUuid randId
   Id.fromUuid randUuid === randId
+
+textToId :: Property
+textToId = property $ do
+  randUuid <- UUID.toText <$> liftIO UUID.nextRandom
+  case Id.fromText randUuid of
+    Nothing     -> failure
+    Just randId -> toText randId === randUuid
+
+idToText :: Property
+idToText = property $ do
+  randId <- getRandomId
+  let randText = toText randId
+  case Id.fromText randText of
+    Nothing         -> failure
+    Just idFromText -> idFromText === randId


### PR DESCRIPTION
This PR adds a cleanup feature to remove expired capabilities from collections.
A job in the persistence server runs this cleanup every 60 minutes and when the server is started.

Fixes #52 