### PR TITLE
Upgrade to GHC 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: haskell/actions/setup@93635e8c4ac823f55cf3444537a63d3f2fd589de
         id: setup-haskell-cabal
         with:
-          ghc-version: "9.0"
+          ghc-version: "9.2"
           cabal-version: "latest"
 
       - name: Update Hackage snapshot

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -33,10 +33,7 @@ jobs:
             pkg update
 
             # Install dependencies.
-            # The GHC 8.10 port only contains the versioned ghc binary,
-            # so we provide a symlink here because Cabal requires it.
-            pkg install -y ghc810 hs-cabal-install
-            ln -s /usr/local/bin/ghc-8.10.7 /usr/local/bin/ghc
+            pkg install -y ghc hs-cabal-install
 
             # Disable generation of documentation. Overriding this via cli
             # flags is broken.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="mkoppmann <dev@mkoppmann.at>"
 ###############
 # Build image #
 ###############
-FROM utdemir/ghc-musl:v24-ghc902@sha256:3ee9b1bd447b9c51752a57e0fb0d0223be0e1c982b7a30776310743b514fcd1f AS build
+FROM utdemir/ghc-musl:v24-ghc922@sha256:e0eafa9a550657b37066e4e23ae5d5a5a6ca3a7b007e0031cffa0f65e77b31f4 AS build
 
 # Install upx for shrinking the binary
 RUN apk --no-cache add upx=~3.96

--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -5,12 +5,12 @@ license:            EUPL-1.2
 license-file:       LICENSE
 maintainer:         mkoppmann <dev@mkoppmann.at>
 author:             Michael Koppmann
-tested-with:        ghc ==9.0.2
+tested-with:        ghc ==9.2
 homepage:           https://github.com/mkoppmann/eselsohr
 bug-reports:        https://github.com/mkoppmann/eselsohr/issues
 category:           Web
-extra-source-files: CHANGELOG.md
 data-files:         static/style.css
+extra-source-files: CHANGELOG.md
 
 library
     exposed-modules:
@@ -105,39 +105,39 @@ library
 
     build-depends:
         aeson >=2.0.3 && <2.2,
-        base >=4.15.1 && <4.18,
+        base >=4.16 && <4.18,
         base32 >=0.2.2 && <0.3,
         co-log >=0.5.0 && <0.6,
-        dotenv >=0.9.0 && <0.10,
+        dotenv >=0.9.0.2 && <0.11,
         exceptions >=0.10.4 && <0.11,
         filepath >=1.4.2 && <1.5,
         http-api-data >=0.4.3 && <0.6,
-        http-client >=0.7.11 && <0.8,
-        http-client-restricted >=0.0.4 && <0.1,
+        http-client >=0.7.13 && <0.8,
+        http-client-restricted >=0.0.5 && <0.1,
         http-client-tls >=0.3.6 && <0.4,
-        ip >=1.7.4 && <1.8,
+        ip >=1.7.6 && <1.8,
         lucid >=2.11.1 && <2.12,
         microlens >=0.4.12 && <0.5,
-        modern-uri >=0.3.4 && <0.4,
+        modern-uri >=0.3.6 && <0.4,
         mtl >=2.2.2 && <2.4,
         network >=3.1.2 && <3.2,
-        relude >=1.0.0 && <1.2,
+        relude >=1.1.0 && <1.2,
         scalpel >=0.6.2 && <0.7,
-        serialise >=0.2.5 && <0.3,
+        serialise >=0.2.6 && <0.3,
         serialise-uuid >=0.1 && <0.2,
-        servant >=0.19 && <0.20,
+        servant >=0.19.1 && <0.20,
         servant-lucid >=0.9.0 && <0.10,
-        servant-server >=0.19.1 && <0.20,
-        time >=1.9.3 && <1.14,
+        servant-server >=0.19.2 && <0.20,
+        time >=1.11.1 && <1.14,
         tls >=1.5.8 && <1.7,
-        unliftio >=0.2.22 && <0.3,
+        unliftio >=0.2.23 && <0.3,
         uuid >=1.3.15 && <1.4,
         validation-selective >=0.1.0 && <0.2,
         wai >=3.2.3 && <3.3,
         wai-enforce-https >=1.0.0 && <1.1,
-        wai-extra >=3.1.12 && <3.2,
-        warp >=3.3.21 && <3.4,
-        warp-tls >=3.3.2 && <3.4,
+        wai-extra >=3.1.13 && <3.2,
+        warp >=3.3.23 && <3.4,
+        warp-tls >=3.3.4 && <3.4,
         zlib >=0.6.3 && <0.7
 
     mixins:
@@ -151,9 +151,9 @@ executable eselsohr-exe
     default-language: Haskell2010
     ghc-options:      -threaded -rtsopts -with-rtsopts=-N
     build-depends:
-        base >=4.15.1 && <4.18,
+        base >=4.16 && <4.18,
         eselsohr,
-        optparse-applicative >=0.16.1 && <0.18
+        optparse-applicative >=0.17 && <0.18
 
 test-suite eselsohr-test
     type:               exitcode-stdio-1.0
@@ -203,29 +203,29 @@ test-suite eselsohr-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.15.1 && <4.18,
-        bytestring >=0.10.12 && <0.12,
+        base >=4.16 && <4.18,
+        bytestring >=0.11.3 && <0.12,
         co-log >=0.5.0 && <0.6,
         eselsohr,
         filepath >=1.4.2 && <1.5,
-        hedgehog >=1.0.5 && <1.3,
-        hspec >=2.8.5 && <2.11,
+        hedgehog >=1.1 && <1.3,
+        hspec >=2.8.4 && <2.11,
         hspec-wai >=0.11.1 && <0.12,
         http-api-data >=0.4.3 && <0.6,
         http-types >=0.12.3 && <0.13,
         mtl >=2.2.2 && <2.4,
-        relude >=1.0.0 && <1.2,
-        servant >=0.19 && <0.20,
-        tasty >=1.4.2 && <1.5,
+        relude >=1.1.0 && <1.2,
+        servant >=0.19.1 && <0.20,
+        tasty >=1.4.2.3 && <1.5,
         tasty-hedgehog >=1.1.0 && <1.5,
         tasty-hspec >=1.2.0 && <1.3,
         temporary >=1.3 && <1.4,
-        time >=1.9.3 && <1.14,
-        unliftio >=0.2.22 && <0.3,
+        time >=1.11.1 && <1.14,
+        unliftio >=0.2.23 && <0.3,
         uuid >=1.3.15 && <1.4,
         wai >=3.2.3 && <3.3,
-        wai-extra >=3.1.12 && <3.2,
-        warp >=3.3.21 && <3.4
+        wai-extra >=3.1.13 && <3.2,
+        warp >=3.3.23 && <3.4
 
     mixins:
         base hiding (Prelude),

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668912770,
-        "narHash": "sha256-Nzt7ALUl5PrUAYIH8aRbj+njkJZVQ4VQBkWx+qQvqyM=",
+        "lastModified": 1672397839,
+        "narHash": "sha256-o+TBFFNSdOu5L1CUetXGMSinghqqlWcI2Sj9GVoJmUY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "862277ac9d34273cd953f42061e23d488d6b7e8b",
+        "rev": "a3f612564c15e8471dd17c15efaf7ede83c57763",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         overlays = [ ];
         pkgs =
           import nixpkgs { inherit system overlays; config.allowBroken = true; };
-        hp = pkgs.haskell.packages.ghc902;
+        hp = pkgs.haskell.packages.ghc92;
         project = returnShellEnv:
           hp.developPackage {
             inherit returnShellEnv;

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
               pkgs.haskell.lib.addBuildTools drv (with hp;
               [
                 # Specify your build/dev dependencies here.
-                brittany
                 cabal-fmt
                 cabal-install
                 ghcid

--- a/src/Lib/Ui/Web/Page/Layout.hs
+++ b/src/Lib/Ui/Web/Page/Layout.hs
@@ -12,7 +12,7 @@ render page = doctypehtml_ $ do
     head_ $ do
         title_ "Eselsohr"
         meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
-        link_ [rel_ "stylesheet", type_ "text/css", href_ "static/style.css"]
+        link_ [rel_ "stylesheet", type_ "text/css", href_ "/static/style.css"]
     body_ $ do
         header
         main_ page


### PR DESCRIPTION
Fixes #158 

This also fixes the broken FreeBSD build. They only provide packages for GHC 8.10.7 and 9.2, not 9.0.