### PR TITLE
Upgrade Haskell base image to 9.2.7-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="mkoppmann <dev@mkoppmann.at>"
 ###############
 # Build image #
 ###############
-FROM haskell:9.2.5@sha256:3d80672b3174724d88a99305fa78d1e663c1bd95f53dfd744b256b0e4734b241 AS build
+FROM haskell:9.2.7-slim@sha256:c8e991032dae465648df40a9cac5ca26b3e5bb416728f56abff53bbf684e95b7 AS build
 
 # Create the data folder for the deployment stage here, because there is no
 # shell in distroless images available.


### PR DESCRIPTION
The new slim package is smaller so we save some space.