### PR TITLE
Move to GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: haskell-actions/setup@dd344bc1cec854a369df8814ce17ef337d6e6170
         id: setup-haskell-cabal
         with:
-          ghc-version: "9.4"
+          ghc-version: "9.8"
           cabal-version: "latest"
 
       - name: Update Hackage snapshot

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="mkoppmann <dev@mkoppmann.at>"
 ###############
 # Build image #
 ###############
-FROM haskell:9.4-slim@sha256:05c991e739da861079f7a3213020818ebbd8d3d62ac212584bab7736f9e5ec95 AS build
+FROM haskell:9.8-slim@sha256:0875140e7fbcdf71702a5f12457be551cf90e07da7241fd07476b5e61f9d1662 AS build
 
 # Create the data folder for the deployment stage here, because there is no
 # shell in distroless images available.
@@ -50,7 +50,7 @@ COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.
 COPY --from=build /usr/lib/x86_64-linux-gnu/libgmp.so.10 /usr/lib/x86_64-linux-gnu/libgmp.so.10
 
 # Copy executable from build stage
-COPY --from=build /home/builder/.cabal/bin/eselsohr-exe /app/eselsohr
+COPY --from=build /home/builder/.local/bin/eselsohr-exe /app/eselsohr
 
 # Copy static folder from build stage
 COPY --from=build --chown=nonroot:nonroot /build/static /app/static

--- a/eselsohr.cabal
+++ b/eselsohr.cabal
@@ -5,7 +5,7 @@ license:            EUPL-1.2
 license-file:       LICENSE
 maintainer:         mkoppmann <dev@mkoppmann.at>
 author:             Michael Koppmann
-tested-with:        ghc ==9.4
+tested-with:        ghc ==9.8
 homepage:           https://github.com/mkoppmann/eselsohr
 bug-reports:        https://github.com/mkoppmann/eselsohr/issues
 category:           Web
@@ -104,40 +104,37 @@ library
         -fwrite-ide-info -hiedir=.hie -Wunused-packages -j -freverse-errors
 
     build-depends:
-        aeson ^>=2.1.2,
-        base ^>=4.17.2,
-        base32 ^>=0.3.1,
-        co-log ^>=0.6.0,
-        dotenv ^>=0.11.0,
-        exceptions ^>=0.10.5,
-        filepath ^>=1.4.2,
-        http-api-data ^>=0.5,
-        http-client ^>=0.7.14,
-        http-client-tls ^>=0.3.6,
-        ip ^>=1.7.7,
+        aeson ^>=2.2.3,
+        base ^>=4.19.1.0,
+        base32 ^>=0.4,
+        co-log ^>=0.6.1,
+        dotenv ^>=0.12.0,
+        exceptions ^>=0.10.9,
+        filepath ^>=1.5.3,
+        http-api-data ^>=0.6.1,
+        ip ^>=1.7.8,
         lucid ^>=2.11.20230408,
         microlens ^>=0.4.13,
         modern-uri ^>=0.3.6,
-        mtl ^>=2.2.2,
-        network ^>=3.1.4,
-        relude ^>=1.2.1,
+        mtl ^>=2.3.1,
+        relude ^>=1.2.2,
         scalpel ^>=0.6.2,
         serialise ^>=0.2.6,
         serialise-uuid ^>=0.1,
-        servant ^>=0.19.1,
+        servant ^>=0.20.2,
         servant-lucid ^>=0.9.0,
-        servant-server ^>=0.19.2,
+        servant-server ^>=0.20.2,
         time ^>=1.12.2,
-        tls ^>=1.9.0,
+        tls ^>=2.1.4,
         unliftio ^>=0.2.25,
-        uuid ^>=1.3.15,
+        uuid ^>=1.3.16,
         validation-selective ^>=0.2.0,
-        wai ^>=3.2.3,
+        wai ^>=3.2.4,
         wai-enforce-https ^>=1.0.0,
-        wai-extra ^>=3.1.13,
-        warp ^>=3.3.29,
-        warp-tls ^>=3.4.3,
-        zlib ^>=0.6.3
+        wai-extra ^>=3.1.17,
+        warp ^>=3.4.4,
+        warp-tls ^>=3.4.11,
+        zlib ^>=0.7.1
 
     mixins:
         base hiding (Prelude),
@@ -150,7 +147,7 @@ executable eselsohr-exe
     default-language: Haskell2010
     ghc-options:      -threaded -rtsopts -with-rtsopts=-N
     build-depends:
-        base ^>=4.17.2,
+        base ^>=4.19.1.0,
         eselsohr,
         optparse-applicative ^>=0.18.1
 
@@ -202,29 +199,29 @@ test-suite eselsohr-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base ^>=4.17.2,
+        base ^>=4.19.1.0,
         bytestring ^>=0.11.5,
-        co-log ^>=0.6.0,
+        co-log ^>=0.6.1,
         eselsohr,
-        filepath ^>=1.4.2,
-        hedgehog ^>=1.4,
-        hspec ^>=2.11.5,
+        filepath ^>=1.5.3,
+        hedgehog ^>=1.5,
+        hspec ^>=2.11.7,
         hspec-wai ^>=0.11.1,
-        http-api-data ^>=0.5,
-        http-types ^>=0.12.3,
-        mtl ^>=2.2.2,
-        relude ^>=1.2.1,
-        servant ^>=0.19.1,
+        http-api-data ^>=0.6.1,
+        http-types ^>=0.12.4,
+        mtl ^>=2.3.1,
+        relude ^>=1.2.2,
+        servant ^>=0.20.2,
         tasty ^>=1.5,
         tasty-hedgehog ^>=1.4.0,
         tasty-hspec ^>=1.2.0,
         temporary ^>=1.3,
         time ^>=1.12.2,
         unliftio ^>=0.2.25,
-        uuid ^>=1.3.15,
-        wai ^>=3.2.3,
-        wai-extra ^>=3.1.13,
-        warp ^>=3.3.29
+        uuid ^>=1.3.16,
+        wai ^>=3.2.4,
+        wai-extra ^>=3.1.17,
+        warp ^>=3.4.4
 
     mixins:
         base hiding (Prelude),

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696419054,
-        "narHash": "sha256-EdR+dIKCfqL3voZUDYwcvgRDOektQB9KbhBVcE0/3Mo=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7131f3c223a2d799568e4b278380cd9dac2b8579",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           pkgs.haskell.lib.doJailbreak (pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.unmarkBroken pkg));
         hp = pkgs.haskell.packages.ghc98.override {
           overrides = hself: hsuper: {
-            # typerep-map = jailbreakUnbreak hsuper.typerep-map;
+            base32 = jailbreakUnbreak hsuper.base32;
           };
         };
         project = returnShellEnv:

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
                   ghcid
                   haskell-language-server
                   pkgs.nixpkgs-fmt
+                  pkgs.zlib
                 ]);
             });
       in

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,9 @@
           import nixpkgs { inherit system overlays; config.allowBroken = true; };
         jailbreakUnbreak = pkg:
           pkgs.haskell.lib.doJailbreak (pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.unmarkBroken pkg));
-        hp = pkgs.haskell.packages.ghc94.override {
+        hp = pkgs.haskell.packages.ghc98.override {
           overrides = hself: hsuper: {
-            typerep-map = jailbreakUnbreak hsuper.typerep-map;
+            # typerep-map = jailbreakUnbreak hsuper.typerep-map;
           };
         };
         project = returnShellEnv:

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -106,8 +106,6 @@ runServer Config.Config{..} env@Env.Env{..} = do
         , TLS.cipher_ECDHE_RSA_AES256GCM_SHA384
         , TLS.cipher_ECDHE_ECDSA_CHACHA20POLY1305_SHA256
         , TLS.cipher_ECDHE_RSA_CHACHA20POLY1305_SHA256
-        , TLS.cipher_DHE_RSA_AES128GCM_SHA256
-        , TLS.cipher_DHE_RSA_AES256GCM_SHA384
         ]
 
 warpSettings :: String -> Port -> Settings

--- a/src/Lib/Ui/Server.hs
+++ b/src/Lib/Ui/Server.hs
@@ -10,7 +10,7 @@ import Network.Wai.Handler.Warp (Port)
 import Network.Wai.Middleware.AddHeaders (addHeaders)
 import Network.Wai.Middleware.AddHsts (addHsts)
 import Network.Wai.Middleware.Gzip
-    ( def
+    ( defaultGzipSettings
     , gzip
     )
 import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
@@ -54,7 +54,7 @@ application port staticFolder env@Env.Env{..} =
         & addSecurityHeaders
         & realIpHeader "X-Forwarded-For"
         & hstsHeader
-        & gzip def
+        & gzip defaultGzipSettings
   where
     enforceHttps :: Middleware
     enforceHttps = case https of


### PR DESCRIPTION
Generated new version bounds with cabal-plan-bounds. `base32` needs an override currently. `nix build` and `nix shell` are working but `nix develop` fails.